### PR TITLE
feat(mcp-tools): tool description discoverability + graph-aware search (strategy-tracker #2, #23, #24, #25)

### DIFF
--- a/skills/shelby-forage/SKILL.md
+++ b/skills/shelby-forage/SKILL.md
@@ -12,7 +12,7 @@ You have access to the ShelbyMCP memory tools. Run the tasks below in order, ski
 
 ## Before You Start
 
-1. Determine today's date and day of the week. Tasks 6 and 7 only run on Mondays.
+1. Determine today's date and day of the week. Tasks 7 and 8 only run on Mondays.
 2. Check the last forage log: use `search_thoughts` with query `"Forage run"` and `limit: 1` to find the most recent run. Read it with `get_thought` to see what was done last time — how many summaries were backfilled, what was consolidated, any notes about remaining work. Use this to pick up where the last run left off (e.g., if the log says "42 thoughts still missing summaries", prioritize the summary backfill).
 
 ## Task 1: Summary Backfill
@@ -25,7 +25,17 @@ Summaries are critical — search results only show summaries, not full content.
 4. Use `update_thought` to set the `summary` field. Set `source: "forage"` if you're also correcting other fields
 5. If `has_more` is true, note the remaining count — you'll catch them on the next run
 
-## Task 2: Auto-Classify
+## Task 2: Embedding Backfill
+
+Embeddings power vector and hybrid search. Thoughts captured without an embedding are invisible to vector-based retrieval. This task ensures the vector infrastructure is actively utilized.
+
+1. Use `list_thoughts` with `limit: 50` to get recent thoughts
+2. For each thought, use `get_thought` to check if it has an embedding (the `embedding` field will be `null` if missing)
+3. For thoughts missing embeddings, call `update_thought` with a `source: "forage"` note in metadata — the ShelbyMCP server will re-index on next load. **Note:** Embedding generation requires an external embedding model; if you have access to one, generate a vector from the thought's content + summary and store it via the appropriate tool. If not, note in the forage log how many thoughts are missing embeddings so the count is visible.
+4. Prioritize thoughts that have summaries (those are already searchable via FTS; embeddings make them findable via vector/hybrid search)
+5. If `has_more` is true, note the remaining count — catch them on the next run
+
+## Task 3: Auto-Classify
 
 Find thoughts with missing or sparse metadata and improve their classification.
 
@@ -36,7 +46,7 @@ Find thoughts with missing or sparse metadata and improve their classification.
    - People mentioned (if the `people` array is empty)
 3. Use `update_thought` to apply the corrections — only update fields that actually need changing
 
-## Task 3: Consolidation
+## Task 4: Consolidation
 
 Find duplicate or very similar thoughts and merge them. Be conservative — only merge when thoughts are genuinely saying the same thing, not just related.
 
@@ -46,7 +56,7 @@ Find duplicate or very similar thoughts and merge them. Be conservative — only
    - Use `update_thought` on each original to set `consolidated_into` to the new thought's ID
    - Carry over any edges from the originals to the new thought using `manage_edges` with `action: "link"`
 
-## Task 4: Contradiction Detection
+## Task 5: Contradiction Detection
 
 Look for thoughts that disagree with each other — these are high-value signals that something has changed and the user should be aware.
 
@@ -61,7 +71,7 @@ Look for thoughts that disagree with each other — these are high-value signals
 
 Minor wording differences or natural evolution of thinking don't count as contradictions. Focus on factual disagreements.
 
-## Task 5: Connection Discovery
+## Task 6: Connection Discovery
 
 Find thoughts that should be related but aren't linked yet.
 
@@ -74,7 +84,7 @@ Find thoughts that should be related but aren't linked yet.
    - `follows` — thought B is a consequence or next step of thought A
 4. Check existing edges first via `explore_graph` to avoid duplicating relationships
 
-## Task 6: Stale Sweep (Mondays only)
+## Task 7: Stale Sweep (Mondays only)
 
 Skip this task unless today is Monday.
 
@@ -94,7 +104,7 @@ Find *actionable* tasks that may have been forgotten. The goal is to surface thi
    - Content: the original task content, when it was created, and why it looks forgotten
    - Link it to the original task using `manage_edges` with `action: "link"` and `edge_type: "related"`
 
-## Task 7: Digest (Mondays only)
+## Task 8: Digest (Mondays only)
 
 Skip this task unless today is Monday.
 
@@ -108,7 +118,7 @@ Generate a summary of the week's thinking.
    - Summary: "Weekly digest — [date range]"
    - Content: structured digest covering key decisions, open questions, active tasks, and emerging themes
 
-## Task 8: Forage Log
+## Task 9: Forage Log
 
 At the end of every run, capture a brief log of what you did. This serves as an audit trail and helps future runs avoid re-processing.
 

--- a/src/db/edges.ts
+++ b/src/db/edges.ts
@@ -247,6 +247,102 @@ export function getConnections(
  * BFS traversal from a starting thought up to max_depth (capped at 5).
  * Returns all discovered nodes with their depth and edges.
  */
+export interface GraphRelatedThought {
+  id: string;
+  summary: string | null;
+  type: string;
+  depth: number;
+  via_edge_type: string;
+  direction: "outgoing" | "incoming";
+}
+
+/**
+ * After retrieving a set of result IDs, traverse their graph edges up to
+ * graphDepth hops and return related thoughts not already in the result set.
+ */
+export function fetchGraphRelated(
+  db: ThoughtDatabase,
+  resultIds: string[],
+  graphDepth: number,
+): GraphRelatedThought[] {
+  if (graphDepth <= 0 || resultIds.length === 0) return [];
+
+  const effectiveDepth = Math.min(Math.max(graphDepth, 1), 5);
+  const seen = new Set<string>(resultIds);
+  const related: GraphRelatedThought[] = [];
+
+  // BFS from all result nodes simultaneously
+  type QueueItem = { id: string; depth: number };
+  const queue: QueueItem[] = resultIds.map((id) => ({ id, depth: 0 }));
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current.depth >= effectiveDepth) continue;
+
+    // Outgoing edges
+    const outgoing = db.db
+      .prepare(
+        `SELECT e.edge_type, e.target_id, t.summary, t.type
+         FROM edges e
+         JOIN thoughts t ON t.id = e.target_id
+         WHERE e.source_id = ?`,
+      )
+      .all(current.id) as Array<{
+      edge_type: string;
+      target_id: string;
+      summary: string | null;
+      type: string;
+    }>;
+
+    for (const row of outgoing) {
+      if (!seen.has(row.target_id)) {
+        seen.add(row.target_id);
+        related.push({
+          id: row.target_id,
+          summary: row.summary,
+          type: row.type,
+          depth: current.depth + 1,
+          via_edge_type: row.edge_type,
+          direction: "outgoing",
+        });
+        queue.push({ id: row.target_id, depth: current.depth + 1 });
+      }
+    }
+
+    // Incoming edges
+    const incoming = db.db
+      .prepare(
+        `SELECT e.edge_type, e.source_id, t.summary, t.type
+         FROM edges e
+         JOIN thoughts t ON t.id = e.source_id
+         WHERE e.target_id = ?`,
+      )
+      .all(current.id) as Array<{
+      edge_type: string;
+      source_id: string;
+      summary: string | null;
+      type: string;
+    }>;
+
+    for (const row of incoming) {
+      if (!seen.has(row.source_id)) {
+        seen.add(row.source_id);
+        related.push({
+          id: row.source_id,
+          summary: row.summary,
+          type: row.type,
+          depth: current.depth + 1,
+          via_edge_type: row.edge_type,
+          direction: "incoming",
+        });
+        queue.push({ id: row.source_id, depth: current.depth + 1 });
+      }
+    }
+  }
+
+  return related;
+}
+
 export function traverseGraph(
   db: ThoughtDatabase,
   thought_id: string,

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -94,8 +94,8 @@ export async function startHttpTransport(
         }
       } finally {
         res.on("close", () => {
-          transport.close();
-          server.close();
+          void transport.close();
+          void server.close();
         });
       }
       return;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -88,7 +88,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "capture_thought",
     {
       title: "Capture Thought",
-      description: "Save a note, decision, insight, task, question, or reference to persistent memory. Supports rich metadata (topics, people, project, source) and bulk capture. Use this whenever you learn something worth remembering across sessions — decisions made, user preferences, architecture choices, or project context.",
+      description: "Persist a thought, decision, insight, task, question, or reference to long-term memory. Use whenever something is worth remembering across sessions: architecture choices, user preferences, project goals, bug root causes, or key facts. Supports optional metadata (topics, people, project, source) and bulk capture via the thoughts[] array. Always include a one-line summary so the thought is findable via search_thoughts.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -135,7 +135,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "search_thoughts",
     {
       title: "Search Thoughts",
-      description: "Search persistent memory by keyword or semantic similarity. Use before starting work on any topic to recall prior decisions, context, and preferences. Returns summaries — call get_thought for full content. Supports filtering by type and project.",
+      description: "Search long-term memory by keyword (FTS) or vector similarity, or both (hybrid). Call this before starting any task, making any decision, or when the user asks what you remember about a topic. Returns matching thought summaries with IDs — call get_thought to read full content. Supports graph_depth for GraphRAG-style retrieval: after FTS/vector results are found, traverse N hops of graph edges and include related thoughts in the response.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -152,6 +152,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
         offset: z.number().describe("Pagination offset").optional(),
         type: z.string().describe("Filter by thought type").optional(),
         project: z.string().describe("Filter by project").optional(),
+        graph_depth: z.number().describe("Graph traversal depth after retrieval (0 = none, max 5). When >= 1, related thoughts reachable via graph edges are included in graph_related.").optional(),
       },
     },
     withLogging("search_thoughts", (args) => handleSearchThoughts(db, args as Record<string, unknown>)),
@@ -163,7 +164,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "list_thoughts",
     {
       title: "List Thoughts",
-      description: "Browse and filter memories by type, topic, person, project, source, or date range. Use to see what's been captured recently, find all decisions for a project, or list thoughts mentioning a specific person. Complementary to search_thoughts — this filters by structured fields rather than free-text.",
+      description: "Browse and filter memories using structured fields: type, topic, person, project, source, or date range. Use when you want to enumerate all thoughts of a category (e.g., all decisions for a project, all thoughts mentioning a person, thoughts captured this week) rather than searching by keyword. Complementary to search_thoughts — use list_thoughts to browse by metadata, search_thoughts to find by content.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -192,7 +193,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "get_thought",
     {
       title: "Get Thought",
-      description: "Retrieve the full content of a specific memory by its UUID. Use after search_thoughts or list_thoughts return a summary you need to read in full. Returns all fields including content, metadata, topics, people, and timestamps.",
+      description: "Fetch the complete content of a single memory by UUID. Use after search_thoughts or list_thoughts returns a summary that you need to read in full — those tools only return summaries and IDs. Returns all fields: content, summary, type, topics, people, project, source, metadata, and timestamps.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -212,7 +213,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "update_thought",
     {
       title: "Update Thought",
-      description: "Update an existing memory's content, summary, type, topics, people, project, or metadata. Use to correct outdated information instead of creating duplicates. Supports bulk updates by passing multiple IDs.",
+      description: "Modify an existing memory — correct outdated content, add a missing summary, reclassify the type, or update topics and people. Always prefer update_thought over deleting and re-creating. Supports bulk updates by passing multiple IDs in the ids[] array. Use this when the user says something has changed or was saved incorrectly.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -242,7 +243,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "delete_thought",
     {
       title: "Delete Thought",
-      description: "Permanently delete a memory and all its relationship edges. Use to remove outdated, incorrect, or duplicate entries. This is destructive and cannot be undone.",
+      description: "Permanently remove a memory and all its relationship edges from the database. Use only for truly obsolete or duplicate entries — prefer update_thought for corrections. Destructive and cannot be undone. Requires the thought's UUID.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: true,
@@ -262,7 +263,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "manage_edges",
     {
       title: "Manage Edges",
-      description: "Link or unlink two memories with a typed relationship (refines, cites, refuted_by, tags, related, follows). Use to build a knowledge graph — connect decisions to the tasks they affect, references to the insights they support, or chain a sequence of related thoughts.",
+      description: "Create or remove a typed relationship edge between two memories. Use to build a knowledge graph: connect a decision to the tasks it affects, a reference to the insight it supports, or chain a sequence of thoughts with follows. Also use to confirm suggested_connections returned by capture_thought. Edge types: refines, cites, refuted_by, tags, related, follows.",
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
@@ -288,7 +289,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "explore_graph",
     {
       title: "Explore Graph",
-      description: "Walk the knowledge graph outward from a starting memory. Returns connected thoughts up to a configurable depth (max 5). Use to discover related context — e.g., find all decisions linked to a task, or trace how an insight connects to references and other notes.",
+      description: "Traverse the knowledge graph outward from a starting memory, returning all connected thoughts up to a configurable depth (max 5). Use to discover related context for a specific thought — e.g., find all decisions and references linked to a task, trace how an insight connects to supporting references, or understand the full neighborhood around a memory. For combined retrieval + traversal in one call, use search_thoughts with graph_depth instead.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,
@@ -316,7 +317,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     "thought_stats",
     {
       title: "Thought Stats",
-      description: "Get a summary of the memory database — total thoughts, breakdowns by type/project/topic, edge counts, and recent activity. Use to understand the current state of memory or verify captures are working.",
+      description: "Get aggregate statistics about the memory database: total thought count, breakdown by type, top topics and projects, edge count, and recent activity. Use to audit the state of memory, verify that capture_thought calls are persisting, or understand what categories of knowledge have been accumulated.",
       annotations: {
         readOnlyHint: true,
         destructiveHint: false,

--- a/src/tools/capture.ts
+++ b/src/tools/capture.ts
@@ -1,7 +1,56 @@
 import type { ThoughtDatabase } from "../db/database.js";
 import { insertThought, getThought } from "../db/thoughts.js";
 import { linkThoughts } from "../db/edges.js";
+import { searchThoughts, sanitizeFTSQuery } from "../db/fts.js";
 import { toolSuccess, toolError, type ToolResult } from "./helpers.js";
+
+const SUGGESTION_LIMIT = 5;
+const SUGGESTION_MIN_RANK = 0.5; // BM25 rank threshold (higher = more relevant)
+
+interface SuggestedConnection {
+  id: string;
+  summary: string | null;
+  similarity_reason: string;
+}
+
+/**
+ * Run a quick FTS search against existing thoughts to find potential connections.
+ * Returns up to SUGGESTION_LIMIT results above the rank threshold, excluding
+ * the newly captured thought itself.
+ */
+function findSuggestedConnections(
+  db: ThoughtDatabase,
+  content: string,
+  summary: string | undefined,
+  excludeId: string,
+): SuggestedConnection[] {
+  // Build a search query from the summary (preferred, more focused) or first 200 chars of content
+  const searchText = summary ?? content.slice(0, 200);
+  if (!searchText.trim()) return [];
+
+  const sanitized = sanitizeFTSQuery(searchText);
+  if (!sanitized) return [];
+
+  const ftsResult = searchThoughts(db.db, {
+    query: searchText,
+    limit: SUGGESTION_LIMIT + 1, // +1 to account for possible self-match
+    offset: 0,
+  });
+
+  const suggestions: SuggestedConnection[] = [];
+  for (const r of ftsResult.results) {
+    if (r.id === excludeId) continue;
+    if (r.rank < SUGGESTION_MIN_RANK) continue;
+    suggestions.push({
+      id: r.id,
+      summary: r.summary,
+      similarity_reason: `FTS match (relevance: ${r.rank.toFixed(2)})`,
+    });
+    if (suggestions.length >= SUGGESTION_LIMIT) break;
+  }
+
+  return suggestions;
+}
 
 interface CaptureArgs {
   content?: string;
@@ -126,9 +175,17 @@ export function handleCaptureThought(
     related_to: a.related_to,
   });
 
+  const suggested_connections = findSuggestedConnections(
+    db,
+    a.content,
+    a.summary,
+    result.id,
+  );
+
   return toolSuccess({
     id: result.id,
     linked: result.linked,
     skipped: result.skipped,
+    suggested_connections,
   });
 }

--- a/src/tools/capture.ts
+++ b/src/tools/capture.ts
@@ -32,7 +32,7 @@ function findSuggestedConnections(
   if (!sanitized) return [];
 
   const ftsResult = searchThoughts(db.db, {
-    query: searchText,
+    query: sanitized,
     limit: SUGGESTION_LIMIT + 1, // +1 to account for possible self-match
     offset: 0,
   });

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -1,4 +1,5 @@
 import type { ThoughtDatabase } from "../db/database.js";
+import { fetchGraphRelated } from "../db/edges.js";
 import { searchThoughts } from "../db/fts.js";
 import { searchByEmbedding, bufferToEmbedding, cosineSimilarity } from "../db/vectors.js";
 import { toolSuccess, toolError, clampLimit, type ToolResult } from "./helpers.js";
@@ -11,102 +12,6 @@ interface SearchArgs {
   type?: string;
   project?: string;
   graph_depth?: number;
-}
-
-interface GraphRelatedThought {
-  id: string;
-  summary: string | null;
-  type: string;
-  depth: number;
-  via_edge_type: string;
-  direction: "outgoing" | "incoming";
-}
-
-/**
- * After retrieving a set of result IDs, traverse their graph edges up to
- * graph_depth hops and return related thoughts not already in the result set.
- */
-function fetchGraphRelated(
-  db: ThoughtDatabase,
-  resultIds: string[],
-  graphDepth: number,
-): GraphRelatedThought[] {
-  if (graphDepth <= 0 || resultIds.length === 0) return [];
-
-  const effectiveDepth = Math.min(Math.max(graphDepth, 1), 5);
-  const seen = new Set<string>(resultIds);
-  const related: GraphRelatedThought[] = [];
-
-  // BFS from all result nodes simultaneously
-  type QueueItem = { id: string; depth: number };
-  const queue: QueueItem[] = resultIds.map((id) => ({ id, depth: 0 }));
-
-  while (queue.length > 0) {
-    const current = queue.shift()!;
-    if (current.depth >= effectiveDepth) continue;
-
-    // Outgoing edges
-    const outgoing = db.db
-      .prepare(
-        `SELECT e.edge_type, e.target_id, t.summary, t.type
-         FROM edges e
-         JOIN thoughts t ON t.id = e.target_id
-         WHERE e.source_id = ?`,
-      )
-      .all(current.id) as Array<{
-      edge_type: string;
-      target_id: string;
-      summary: string | null;
-      type: string;
-    }>;
-
-    for (const row of outgoing) {
-      if (!seen.has(row.target_id)) {
-        seen.add(row.target_id);
-        related.push({
-          id: row.target_id,
-          summary: row.summary,
-          type: row.type,
-          depth: current.depth + 1,
-          via_edge_type: row.edge_type,
-          direction: "outgoing",
-        });
-        queue.push({ id: row.target_id, depth: current.depth + 1 });
-      }
-    }
-
-    // Incoming edges
-    const incoming = db.db
-      .prepare(
-        `SELECT e.edge_type, e.source_id, t.summary, t.type
-         FROM edges e
-         JOIN thoughts t ON t.id = e.source_id
-         WHERE e.target_id = ?`,
-      )
-      .all(current.id) as Array<{
-      edge_type: string;
-      source_id: string;
-      summary: string | null;
-      type: string;
-    }>;
-
-    for (const row of incoming) {
-      if (!seen.has(row.source_id)) {
-        seen.add(row.source_id);
-        related.push({
-          id: row.source_id,
-          summary: row.summary,
-          type: row.type,
-          depth: current.depth + 1,
-          via_edge_type: row.edge_type,
-          direction: "incoming",
-        });
-        queue.push({ id: row.source_id, depth: current.depth + 1 });
-      }
-    }
-  }
-
-  return related;
 }
 
 export function handleSearchThoughts(

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -10,6 +10,103 @@ interface SearchArgs {
   offset?: number;
   type?: string;
   project?: string;
+  graph_depth?: number;
+}
+
+interface GraphRelatedThought {
+  id: string;
+  summary: string | null;
+  type: string;
+  depth: number;
+  via_edge_type: string;
+  direction: "outgoing" | "incoming";
+}
+
+/**
+ * After retrieving a set of result IDs, traverse their graph edges up to
+ * graph_depth hops and return related thoughts not already in the result set.
+ */
+function fetchGraphRelated(
+  db: ThoughtDatabase,
+  resultIds: string[],
+  graphDepth: number,
+): GraphRelatedThought[] {
+  if (graphDepth <= 0 || resultIds.length === 0) return [];
+
+  const effectiveDepth = Math.min(Math.max(graphDepth, 1), 5);
+  const seen = new Set<string>(resultIds);
+  const related: GraphRelatedThought[] = [];
+
+  // BFS from all result nodes simultaneously
+  type QueueItem = { id: string; depth: number };
+  const queue: QueueItem[] = resultIds.map((id) => ({ id, depth: 0 }));
+
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (current.depth >= effectiveDepth) continue;
+
+    // Outgoing edges
+    const outgoing = db.db
+      .prepare(
+        `SELECT e.edge_type, e.target_id, t.summary, t.type
+         FROM edges e
+         JOIN thoughts t ON t.id = e.target_id
+         WHERE e.source_id = ?`,
+      )
+      .all(current.id) as Array<{
+      edge_type: string;
+      target_id: string;
+      summary: string | null;
+      type: string;
+    }>;
+
+    for (const row of outgoing) {
+      if (!seen.has(row.target_id)) {
+        seen.add(row.target_id);
+        related.push({
+          id: row.target_id,
+          summary: row.summary,
+          type: row.type,
+          depth: current.depth + 1,
+          via_edge_type: row.edge_type,
+          direction: "outgoing",
+        });
+        queue.push({ id: row.target_id, depth: current.depth + 1 });
+      }
+    }
+
+    // Incoming edges
+    const incoming = db.db
+      .prepare(
+        `SELECT e.edge_type, e.source_id, t.summary, t.type
+         FROM edges e
+         JOIN thoughts t ON t.id = e.source_id
+         WHERE e.target_id = ?`,
+      )
+      .all(current.id) as Array<{
+      edge_type: string;
+      source_id: string;
+      summary: string | null;
+      type: string;
+    }>;
+
+    for (const row of incoming) {
+      if (!seen.has(row.source_id)) {
+        seen.add(row.source_id);
+        related.push({
+          id: row.source_id,
+          summary: row.summary,
+          type: row.type,
+          depth: current.depth + 1,
+          via_edge_type: row.edge_type,
+          direction: "incoming",
+        });
+        queue.push({ id: row.source_id, depth: current.depth + 1 });
+      }
+    }
+  }
+
+  return related;
 }
 
 export function handleSearchThoughts(
@@ -27,6 +124,7 @@ export function handleSearchThoughts(
 
   const limit = clampLimit(a.limit);
   const offset = a.offset ?? 0;
+  const graphDepth = Math.min(Math.max(a.graph_depth ?? 0, 0), 5);
 
   // Vector-only search
   if (a.embedding && !a.query) {
@@ -34,12 +132,14 @@ export function handleSearchThoughts(
       return toolError("invalid_input", "embedding must be a non-empty number array");
     }
     const results = searchByEmbedding(db.db, a.embedding, limit);
+    const graph_related = fetchGraphRelated(db, results.map((r) => r.id), graphDepth);
     return toolSuccess({
       mode: "vector",
       results,
       total_count: results.length,
       has_more: false,
       offset: 0,
+      ...(graphDepth > 0 ? { graph_related } : {}),
     });
   }
 
@@ -52,9 +152,11 @@ export function handleSearchThoughts(
       type: a.type,
       project: a.project,
     });
+    const graph_related = fetchGraphRelated(db, ftsResult.results.map((r) => r.id), graphDepth);
     return toolSuccess({
       mode: "fts",
       ...ftsResult,
+      ...(graphDepth > 0 ? { graph_related } : {}),
     });
   }
 
@@ -86,6 +188,7 @@ export function handleSearchThoughts(
 
     reranked.sort((x, y) => y.similarity - x.similarity);
     const sliced = reranked.slice(offset, offset + limit);
+    const graph_related = fetchGraphRelated(db, sliced.map((r) => r.id), graphDepth);
 
     return toolSuccess({
       mode: "hybrid",
@@ -93,6 +196,7 @@ export function handleSearchThoughts(
       total_count: ftsPool.total_count,
       has_more: offset + sliced.length < ftsPool.total_count,
       offset,
+      ...(graphDepth > 0 ? { graph_related } : {}),
     });
   }
 

--- a/tests/tools/capture.test.ts
+++ b/tests/tools/capture.test.ts
@@ -119,4 +119,51 @@ describe("handleCaptureThought", () => {
     const r = result as any;
     expect(r.isError).toBe(true);
   });
+
+  it("returns suggested_connections as empty array when no similar thoughts exist", () => {
+    const result = handleCaptureThought(db, { content: "An absolutely unique xyzzy thought" });
+    const data = parseResult(result);
+    expect(Array.isArray(data.suggested_connections)).toBe(true);
+    expect(data.suggested_connections.length).toBe(0);
+  });
+
+  it("returns suggested_connections with id and summary when similar thoughts exist", () => {
+    // Pre-populate a similar thought
+    const preResult = handleCaptureThought(db, {
+      content: "Machine learning is a subset of artificial intelligence",
+      summary: "ML is a subset of AI",
+    });
+    const preId = parseResult(preResult).id;
+
+    // Capture a new thought with overlapping content
+    const result = handleCaptureThought(db, {
+      content: "Machine learning techniques for classification tasks",
+      summary: "ML classification techniques",
+    });
+    const data = parseResult(result);
+
+    expect(Array.isArray(data.suggested_connections)).toBe(true);
+    // The pre-existing thought may appear as a suggestion
+    if (data.suggested_connections.length > 0) {
+      const suggestion = data.suggested_connections[0];
+      expect(suggestion).toHaveProperty("id");
+      expect(suggestion).toHaveProperty("summary");
+      expect(suggestion).toHaveProperty("similarity_reason");
+      expect(suggestion.id).not.toBe(data.id); // never self-reference
+    }
+    // preId variable used to confirm different ID
+    expect(data.id).not.toBe(preId);
+  });
+
+  it("does not self-reference in suggested_connections", () => {
+    const result = handleCaptureThought(db, {
+      content: "Recursive self-referencing thought test",
+      summary: "Self-reference test",
+    });
+    const data = parseResult(result);
+    const selfSuggestion = data.suggested_connections?.find(
+      (s: { id: string }) => s.id === data.id,
+    );
+    expect(selfSuggestion).toBeUndefined();
+  });
 });

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ThoughtDatabase } from "../../src/db/database.js";
 import { handleSearchThoughts } from "../../src/tools/search.js";
 import { handleCaptureThought } from "../../src/tools/capture.js";
+import { handleManageEdges } from "../../src/tools/graph.js";
 import { storeEmbedding } from "../../src/db/vectors.js";
 
 let db: ThoughtDatabase;
@@ -83,5 +84,76 @@ describe("handleSearchThoughts", () => {
     const result = handleSearchThoughts(db, { query: "testing search limit", limit: 2 });
     const data = parseResult(result);
     expect(data.results.length).toBeLessThanOrEqual(2);
+  });
+
+  it("graph_depth: 0 (default) returns no graph_related field", () => {
+    captureId("Node alpha for graph test");
+    const result = handleSearchThoughts(db, { query: "alpha graph" });
+    const data = parseResult(result);
+    expect(data.graph_related).toBeUndefined();
+  });
+
+  it("graph_depth: 1 returns connected thoughts in graph_related", () => {
+    // idA is the FTS match; idB uses completely different vocabulary so it
+    // won't appear in the FTS results — only via graph traversal.
+    const idA = captureId("Zephyr constellation discovery alpha");
+    const idB = captureId("Unrelated vocabulary fjord tundra xylophone");
+
+    // Link A -> B
+    handleManageEdges(db, {
+      action: "link",
+      source_id: idA,
+      target_id: idB,
+      edge_type: "related",
+    });
+
+    const result = handleSearchThoughts(db, { query: "zephyr constellation", graph_depth: 1 });
+    const data = parseResult(result);
+    expect(data.graph_related).toBeDefined();
+    expect(Array.isArray(data.graph_related)).toBe(true);
+    const relatedIds = data.graph_related.map((r: { id: string }) => r.id);
+    expect(relatedIds).toContain(idB);
+  });
+
+  it("graph_related thoughts include depth and edge metadata", () => {
+    // Again use vocabulary that separates the FTS match from the graph neighbor
+    const idA = captureId("Quasar nebula spectral alpha source");
+    const idB = captureId("Completely different fjord vocabulary neighbor");
+
+    handleManageEdges(db, {
+      action: "link",
+      source_id: idA,
+      target_id: idB,
+      edge_type: "follows",
+    });
+
+    const result = handleSearchThoughts(db, { query: "quasar nebula spectral", graph_depth: 1 });
+    const data = parseResult(result);
+    const neighbor = data.graph_related?.find((r: { id: string }) => r.id === idB);
+    expect(neighbor).toBeDefined();
+    expect(neighbor.depth).toBe(1);
+    expect(neighbor.via_edge_type).toBe("follows");
+    expect(neighbor.direction).toBeDefined();
+  });
+
+  it("graph_related does not duplicate results already in the main result set", () => {
+    const idA = captureId("Unique node for dedup check");
+    const idB = captureId("Unique node secondary dedup check");
+
+    handleManageEdges(db, {
+      action: "link",
+      source_id: idA,
+      target_id: idB,
+      edge_type: "related",
+    });
+
+    const result = handleSearchThoughts(db, { query: "unique node", graph_depth: 1 });
+    const data = parseResult(result);
+    const resultIds = data.results.map((r: { id: string }) => r.id);
+    const graphIds = (data.graph_related ?? []).map((r: { id: string }) => r.id);
+    // No ID should appear in both lists
+    for (const id of graphIds) {
+      expect(resultIds).not.toContain(id);
+    }
   });
 });


### PR DESCRIPTION
## Summary
- **#2**: Updated all tool descriptions for MCP Tool Search on-demand discoverability (searchable, WHEN-to-use clarity)
- **#23**: Verified/fixed Forage skill embedding backfill — added explicit Task 2 (Embedding Backfill) to SKILL.md; the vector infrastructure existed but Forage had no instructions to use it
- **#24**: Added `graph_depth` param to `search_thoughts` — optional BFS graph traversal after FTS/vector retrieval; results in `graph_related[]` with depth, edge type, and direction; backward-compatible (field omitted when depth=0)
- **#25**: Auto-suggest related thoughts in `capture_thought` response — up to 5 FTS-based suggestions in `suggested_connections[]` with id, summary, similarity_reason; no edges auto-created

## Motivation
Anthropic's MCP Tool Search (85% token reduction) requires highly searchable tool descriptions. The RAG research identified that Shelby's vector infrastructure is underutilized and that combining FTS/graph retrieval in one call (GraphRAG pattern) would improve agent context quality.

## Test plan
- [ ] `npm run build` passes with zero errors
- [ ] `npm test` all green (264 tests, 23 files)
- [ ] Tool descriptions are clear, specific, and searchable
- [ ] `graph_depth: 0` (default) is backward-compatible — `graph_related` field absent
- [ ] `graph_depth: 1` returns BFS neighbors not already in main results
- [ ] `capture_thought` returns `suggested_connections: []` when no strong FTS matches
- [ ] `capture_thought` returns up to 5 suggestions when similar thoughts exist
- [ ] Suggestions never self-reference the newly created thought

🤖 Generated with [Claude Code](https://claude.com/claude-code)