### PR TITLE
overnight: mcp-p1 — 2 items (2026-04-07)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,6 +13,32 @@ If you discover a security vulnerability in ShelbyMCP, please report it responsi
 
 We will acknowledge receipt within 48 hours and aim to release a fix within 7 days for critical issues.
 
+## Known Vulnerabilities
+
+### CVE-2026-0621 — ReDoS in MCP TypeScript SDK UriTemplate regex
+
+| Field | Detail |
+|-------|--------|
+| **CVE** | CVE-2026-0621 |
+| **Severity** | High (ReDoS — remote denial of service) |
+| **Affected package** | `@modelcontextprotocol/sdk` < v2.0.0-alpha.2 |
+| **Current ShelbyMCP version** | `@modelcontextprotocol/sdk` ^1.26.0 |
+| **Fix** | Available in v2.0.0-alpha.2 (alpha — not yet stable) |
+| **Reported** | 2026-04-07 |
+
+**Description**: A Regular Expression Denial of Service (ReDoS) vulnerability exists in the UriTemplate regex parser of the MCP TypeScript SDK. Maliciously crafted URI template strings can cause catastrophic backtracking, blocking the Node.js event loop.
+
+**Attack surface assessment for ShelbyMCP**:
+- The HTTP transport (`--transport http`) exposes a network surface, but ShelbyMCP does not parse untrusted URI templates from incoming requests. The vulnerable code path is only triggered when the SDK itself parses URI templates during request routing — which ShelbyMCP does not exercise with user-supplied template strings.
+- The default stdio transport has no network attack surface.
+- Risk is **low** in practice, but the vulnerability exists in the dependency tree.
+
+**Remediation plan**: Upgrade to `@modelcontextprotocol/sdk` v2 once a stable release is available. SDK v2 introduces a multi-package architecture and breaking changes; the upgrade will be tracked as part of Shelby-MCP's public npm release milestone. Do NOT publish ShelbyMCP to npm while still on the v1 SDK.
+
+**Tracking**: strategy-tracker #32
+
+---
+
 ## Scope
 
 ShelbyMCP stores user thoughts and memories in a local SQLite database. Security considerations include:

--- a/src/mcp/http-transport.ts
+++ b/src/mcp/http-transport.ts
@@ -1,4 +1,9 @@
 import { createServer as createHttpServer, type IncomingMessage, type ServerResponse, type Server } from "node:http";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+// NOTE: @modelcontextprotocol/sdk ^1.26.0 is affected by CVE-2026-0621 (ReDoS in UriTemplate regex).
+// Fixed in v2.0.0-alpha.2. Upgrade to SDK v2 stable once released. See SECURITY.md for details.
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { ThoughtDatabase } from "../db/database.js";
 import { createServerWithDb } from "./server.js";
@@ -7,7 +12,23 @@ import { createOAuthHandlers, verifyBearerToken } from "./oauth.js";
 const MCP_PATH = "/mcp";
 const HEALTH_PATH = "/health";
 const MCP_METADATA_PATH = "/.well-known/mcp.json";
+// MCP Registry v0.1 canonical auto-discovery path (SEP-1649 / SEP-1960)
+// Consumed by VS Code, Copilot, Cursor for server auto-discovery
+const MCP_SERVER_JSON_PATH = "/.well-known/mcp/server.json";
 const OAUTH_METADATA_PATH = "/.well-known/oauth-authorization-server";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function getPackageVersion(): string {
+  try {
+    const pkgPath = resolve(__dirname, "../../package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as { version: string };
+    return pkg.version;
+  } catch {
+    return "0.0.0";
+  }
+}
+
 const REGISTER_PATH = "/register";
 const AUTHORIZE_PATH = "/authorize";
 const TOKEN_PATH = "/token";
@@ -33,11 +54,33 @@ export async function startHttpTransport(
 
     // --- MCP metadata for registry/crawler discovery ---
     if (path === MCP_METADATA_PATH && req.method === "GET") {
+      const version = getPackageVersion();
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({
         name: "shelbymcp",
-        version: "0.2.6",
+        version,
         description: "Knowledge-graph memory server for AI tools",
+        transport: "streamable-http",
+        endpoint: "/mcp",
+        capabilities: {
+          tools: 9,
+          prompts: 3,
+          resources: 1,
+          logging: true,
+          completions: true,
+        },
+      }));
+      return;
+    }
+
+    // --- MCP Registry v0.1 canonical auto-discovery (SEP-1649 / SEP-1960) ---
+    if (path === MCP_SERVER_JSON_PATH && req.method === "GET") {
+      const version = getPackageVersion();
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        name: "shelbymcp",
+        version,
+        description: "Knowledge-graph memory server for AI tools via MCP",
         transport: "streamable-http",
         endpoint: "/mcp",
         capabilities: {

--- a/tests/mcp/well-known.test.ts
+++ b/tests/mcp/well-known.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { startHttpTransport } from "../../src/mcp/http-transport.js";
 import { ThoughtDatabase } from "../../src/db/database.js";
 import type { Server } from "node:http";
+
+const pkg = JSON.parse(readFileSync(resolve(process.cwd(), "package.json"), "utf-8")) as { version: string };
 
 describe(".well-known/mcp.json", () => {
   let server: Server;
@@ -21,15 +25,16 @@ describe(".well-known/mcp.json", () => {
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("application/json");
 
-    const body = await res.json();
+    const body = await res.json() as Record<string, unknown>;
     expect(body.name).toBe("shelbymcp");
-    expect(body.version).toBeDefined();
+    expect(body.version).toBe(pkg.version);
     expect(typeof body.version).toBe("string");
     expect(body.transport).toBe("streamable-http");
     expect(body.endpoint).toBe("/mcp");
     expect(body.capabilities).toBeDefined();
-    expect(body.capabilities.tools).toBe(9);
-    expect(body.capabilities.prompts).toBe(3);
+    const caps = body.capabilities as Record<string, unknown>;
+    expect(caps.tools).toBe(9);
+    expect(caps.prompts).toBe(3);
   });
 
   it("does not require authentication", async () => {
@@ -37,6 +42,45 @@ describe(".well-known/mcp.json", () => {
     server = await startHttpTransport(db, "127.0.0.1", PORT, "test-secret-key");
 
     const res = await fetch(`http://127.0.0.1:${PORT}/.well-known/mcp.json`);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe(".well-known/mcp/server.json (MCP Registry v0.1)", () => {
+  let server: Server;
+  let db: ThoughtDatabase;
+  const PORT = 9878;
+
+  afterEach(() => {
+    server?.close();
+    db?.close();
+  });
+
+  it("returns server metadata at canonical auto-discovery path", async () => {
+    db = new ThoughtDatabase(":memory:");
+    server = await startHttpTransport(db, "127.0.0.1", PORT, null);
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/.well-known/mcp/server.json`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("application/json");
+
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.name).toBe("shelbymcp");
+    expect(body.version).toBe(pkg.version);
+    expect(typeof body.version).toBe("string");
+    expect(body.transport).toBe("streamable-http");
+    expect(body.endpoint).toBe("/mcp");
+    expect(body.capabilities).toBeDefined();
+    const caps = body.capabilities as Record<string, unknown>;
+    expect(caps.tools).toBe(9);
+    expect(caps.prompts).toBe(3);
+  });
+
+  it("does not require authentication", async () => {
+    db = new ThoughtDatabase(":memory:");
+    server = await startHttpTransport(db, "127.0.0.1", PORT, "test-secret-key");
+
+    const res = await fetch(`http://127.0.0.1:${PORT}/.well-known/mcp/server.json`);
     expect(res.status).toBe(200);
   });
 });


### PR DESCRIPTION
## Summary
Security documentation for CVE-2026-0621 (ReDoS in MCP SDK UriTemplate) and canonical `.well-known/mcp/server.json` auto-discovery endpoint per MCP Registry v0.1 spec.

## Strategy Tracker Items
- [x] #32: CVE-2026-0621 documentation and tracking (pending SDK v2 stable)
- [x] #21: Add /.well-known/mcp/server.json canonical path alongside existing /.well-known/mcp.json

## Changes
- security: CVE-2026-0621 documented in SECURITY.md, attack surface assessed as low, inline comment added near SDK import
- mcp-infra: /.well-known/mcp/server.json added per MCP Registry v0.1 / SEP-1649 / SEP-1960; version now read dynamically from package.json (both endpoints)

## Verification
- [x] build passes
- [x] tests pass (293/293)
- [x] self-review completed (no console.log, no any types, no TODO/FIXME)