### PR TITLE
Memory project-scoping self-heal (TS): registry-first resolution, roots, fail-safe scoping, v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shelbymcp",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shelbymcp",
-      "version": "0.2.6",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.26.0",

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -147,6 +147,22 @@ const migrations: Migration[] = [
       `);
     },
   },
+  {
+    version: 7,
+    description: "Normalize legacy display-name project_identifiers to registry slugs",
+    up: (db) => {
+      const map: Array<[string, string]> = [
+        ["Shelby", "shelby"],
+        ["The Crooked Line", "the-crooked-line"],
+        ["KUOW Games", "kuow-games"],
+        ["Ausra Photos", "ausra-photos"],
+      ];
+      const upd = db.prepare("UPDATE thoughts SET project_identifier = ? WHERE project_identifier = ?");
+      for (const [from, to] of map) upd.run(to, from);
+      // Empty-string scope is meaningless — treat as orphan (NULL), repaired later.
+      db.prepare("UPDATE thoughts SET project_identifier = NULL WHERE project_identifier = ''").run();
+    },
+  },
 ];
 
 export function getSchemaVersion(db: Database.Database): number {

--- a/src/db/projects.ts
+++ b/src/db/projects.ts
@@ -102,3 +102,22 @@ export function findProjectByRepo(db: Database.Database, remote: string): Projec
   }
   return null;
 }
+
+/**
+ * Return the registered project whose member_paths contains the longest prefix
+ * of `dir` (exact match or `dir` is a sub-path), or null. This is what lets a
+ * markerless multi-repo container directory resolve to its project slug.
+ */
+export function findProjectByPath(db: Database.Database, dir: string): Project | null {
+  let best: Project | null = null;
+  let bestLen = -1;
+  for (const p of listProjects(db)) {
+    for (const mp of p.memberPaths) {
+      if (mp.length > bestLen && (dir === mp || dir.startsWith(mp + "/"))) {
+        bestLen = mp.length;
+        best = p;
+      }
+    }
+  }
+  return best;
+}

--- a/src/db/resolve-project.ts
+++ b/src/db/resolve-project.ts
@@ -1,7 +1,7 @@
 import type Database from "better-sqlite3";
 import path from "node:path";
 import { detectProject } from "./project-detector.js";
-import { findProjectByRepo, getProjectBySlug, upsertProject, normalizeGitRemote } from "./projects.js";
+import { findProjectByRepo, findProjectByPath, getProjectBySlug, upsertProject, normalizeGitRemote } from "./projects.js";
 
 /** lowercase, spaces/underscores → hyphens, strip other unsafe chars. */
 export function slugify(name: string): string {
@@ -15,6 +15,11 @@ export function slugify(name: string): string {
  * Returns the slug and the detected info, or null if no project marker is found.
  */
 function detectSlug(db: Database.Database, cwd: string): { slug: string; remote: string | null; projectRoot: string } | null {
+  // Registry path match first — handles markerless multi-repo containers and is
+  // setup-portable: the caller's real dir maps to a human-curated slug directly.
+  const byPath = findProjectByPath(db, cwd);
+  if (byPath) return { slug: byPath.slug, remote: null, projectRoot: cwd };
+
   const detected = detectProject(cwd);
   if (!detected) return null;
 

--- a/src/db/seed.ts
+++ b/src/db/seed.ts
@@ -1,0 +1,12 @@
+import type Database from "better-sqlite3";
+import { getProjectBySlug, upsertProject, type Project } from "./projects.js";
+import { DEFAULT_KNOWN_PROJECTS } from "../integrity/seed-data.js";
+
+/** Idempotently seed known projects. Never clobbers a human-confirmed (non-provisional, populated) entry. */
+export function ensureSeedProjects(db: Database.Database, projects: Project[] = DEFAULT_KNOWN_PROJECTS): void {
+  for (const p of projects) {
+    const existing = getProjectBySlug(db, p.slug);
+    if (existing && existing.provisional === false && (existing.memberRepos.length > 0 || existing.memberPaths.length > 0)) continue;
+    upsertProject(db, p);
+  }
+}

--- a/src/integrity/project-repair.ts
+++ b/src/integrity/project-repair.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import { getThought, updateThought, type ThoughtRecord } from "../db/thoughts.js";
+import { getThought, updateThought } from "../db/thoughts.js";
 import { upsertProject, getProjectBySlug, listProjects, type Project } from "../db/projects.js";
 import { DEFAULT_KNOWN_PROJECTS, DEFAULT_TOPIC_CLUSTERS } from "./seed-data.js";
 
@@ -61,7 +61,18 @@ function inferByTopics(topics: string[], topicClusters: Record<string, string>):
   return { slug: null, ambiguous: false };
 }
 
-function classify(t: ThoughtRecord, projects: Project[], topicClusters: Record<string, string>): RepairItem {
+/** Map a capture source/source_agent string to a slug when it unambiguously names one project. */
+function inferBySource(source: string | null): string | null {
+  if (!source) return null;
+  const s = source.toLowerCase();
+  if (s.includes("shelby") || s.includes("graphify")) return "shelby";
+  if (s.includes("crooked") || s.includes("tcl") || s.includes("gdelt") || s.includes("polymarket")) return "the-crooked-line";
+  if (s.includes("ausra")) return "ausra-photos";
+  if (s.includes("kuow")) return "kuow-games";
+  return null;
+}
+
+function classify(t: { id: string; project: string | null; topics: string[]; source: string | null }, projects: Project[], topicClusters: Record<string, string>): RepairItem {
   const byPath = inferByPath(t.project, projects);
   if (byPath) {
     return {
@@ -80,6 +91,15 @@ function classify(t: ThoughtRecord, projects: Project[], topicClusters: Record<s
       reason: `distinctive topic → ${byTopic.slug}`,
     };
   }
+  const bySource = inferBySource(t.source);
+  if (bySource) {
+    return {
+      id: t.id,
+      suggestedSlug: bySource,
+      confidence: "high",
+      reason: `distinctive source → ${bySource}`,
+    };
+  }
   return {
     id: t.id,
     suggestedSlug: null,
@@ -88,12 +108,13 @@ function classify(t: ThoughtRecord, projects: Project[], topicClusters: Record<s
   };
 }
 
-/** Minimal thought shape sufficient for classify() / inferByPath() / inferByTopics(). */
+/** Minimal thought shape sufficient for classify() / inferByPath() / inferByTopics() / inferBySource(). */
 interface RepairCandidate {
   id: string;
   project: string | null;
   topics: string[];
   project_identifier: string | null;
+  source: string | null;
 }
 
 /**
@@ -103,14 +124,15 @@ interface RepairCandidate {
 function repairCandidates(db: Database.Database): RepairCandidate[] {
   const rows = db
     .prepare(
-      "SELECT id, project, project_identifier, topics FROM thoughts WHERE project_identifier IS NULL OR project_identifier = ''",
+      "SELECT id, project, project_identifier, topics, source FROM thoughts WHERE project_identifier IS NULL OR project_identifier = ''",
     )
-    .all() as Array<{ id: string; project: string | null; project_identifier: string | null; topics: string | null }>;
+    .all() as Array<{ id: string; project: string | null; project_identifier: string | null; topics: string | null; source: string | null }>;
   return rows.map((r) => ({
     id: r.id,
     project: r.project,
     project_identifier: r.project_identifier,
     topics: parseJsonArrayRaw(r.topics),
+    source: r.source,
   }));
 }
 
@@ -131,7 +153,7 @@ export function planProjectRepairs(db: Database.Database, topicClusters: Record<
   let scanned = 0;
   for (const t of repairCandidates(db)) {
     scanned++;
-    const item = classify(t as ThoughtRecord, projects, topicClusters);
+    const item = classify(t, projects, topicClusters);
     if (item.confidence === "high") highConfidence.push(item);
     else flagged.push(item);
   }

--- a/src/mcp/resolve-dir.ts
+++ b/src/mcp/resolve-dir.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from "node:url";
+
+export interface RootRef { uri: string }
+
+/** Choose the directory to resolve the project from: first file:// root, else fallback cwd. */
+export function pickResolutionDir(roots: RootRef[] | undefined, fallbackCwd: string): string {
+  for (const r of roots ?? []) {
+    if (r.uri.startsWith("file://")) {
+      try { return fileURLToPath(r.uri); } catch { /* ignore malformed */ }
+    }
+  }
+  return fallbackCwd;
+}

--- a/src/mcp/scope-defaults.ts
+++ b/src/mcp/scope-defaults.ts
@@ -38,7 +38,8 @@ export function applyDefaultScope(
 
   // Attempt to derive the current project slug from cwd.
   const slug = currentProjectSlug(db, cwd);
-  if (!slug) return args;
+  // No slug resolved → fail safe to shared-only (never expose every project).
+  if (!slug) return { ...args, shared_only: true };
 
   return {
     ...args,

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1,5 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { CompleteRequestSchema, SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { CompleteRequestSchema, RootsListChangedNotificationSchema, SetLevelRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import type { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
 import type { ShelbyConfig } from "../config.js";
@@ -17,6 +17,9 @@ import { handleGetBrief } from "../tools/brief.js";
 import { handleSelectContext } from "../tools/context.js";
 import type { ToolResult } from "../tools/helpers.js";
 import { applyDefaultScope } from "./scope-defaults.js";
+import { pickResolutionDir } from "./resolve-dir.js";
+import type { RootRef } from "./resolve-dir.js";
+import { ensureSeedProjects } from "../db/seed.js";
 import {
   MAX_CONTENT_LENGTH,
   MAX_SUMMARY_LENGTH,
@@ -47,6 +50,46 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     name: "shelbymcp",
     version: VERSION,
   });
+
+  // Seed the project registry so resolution can match known paths.
+  ensureSeedProjects(db.db);
+
+  // ---------------------------------------------------------------------------
+  // Client roots — used to resolve the caller's working directory.
+  // The server runs at process.cwd() = "/" in production (launched by macOS app),
+  // so we prefer the first file:// root advertised by the MCP client instead.
+  // ---------------------------------------------------------------------------
+  let clientRoots: RootRef[] | undefined;
+  let rootsFetched = false;
+
+  async function refreshRoots(): Promise<void> {
+    try {
+      const res = await server.server.listRoots();
+      clientRoots = res.roots as RootRef[];
+    } catch {
+      // Client does not support roots — leave clientRoots undefined.
+    }
+    rootsFetched = true;
+  }
+
+  // Re-fetch when the client signals its roots have changed.
+  server.server.setNotificationHandler(RootsListChangedNotificationSchema, () => {
+    void refreshRoots();
+  });
+
+  /** Lazily trigger the first roots fetch (no-op after the first call). */
+  function ensureRoots(): void {
+    if (!rootsFetched) {
+      rootsFetched = true; // set eagerly to prevent concurrent fetches
+      void refreshRoots();
+    }
+  }
+
+  /** The directory to use for project resolution in the current handler call. */
+  function resolutionDir(): string {
+    ensureRoots();
+    return pickResolutionDir(clientRoots, process.cwd());
+  }
 
   // Initialize embedding config from environment
   const embeddingConfig = getEmbeddingConfig();
@@ -157,7 +200,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       },
     },
     withLogging("capture_thought", async (args) => {
-      const result = handleCaptureThought(db, args as Record<string, unknown>);
+      const result = handleCaptureThought(db, args as Record<string, unknown>, resolutionDir());
       // Auto-embed after capture when a server-side embedding provider is configured
       if (!result.isError && embeddingConfig.provider !== "none") {
         try {
@@ -232,7 +275,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       },
     },
     withLogging("search_thoughts", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, process.cwd());
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
       return handleSearchThoughts(db, scoped as Record<string, unknown>);
     }),
   );
@@ -270,7 +313,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       },
     },
     withLogging("list_thoughts", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, process.cwd());
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
       return handleListThoughts(db, scoped as Record<string, unknown>);
     }),
   );
@@ -455,7 +498,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       },
     },
     withLogging("get_brief", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, process.cwd());
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
       return handleGetBrief(db, scoped as Record<string, unknown>);
     }),
   );
@@ -487,7 +530,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       },
     },
     withLogging("select_context", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, process.cwd());
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
       return handleSelectContext(db, scoped as Record<string, unknown>);
     }),
   );

--- a/src/tools/brief.ts
+++ b/src/tools/brief.ts
@@ -25,6 +25,7 @@ export type BriefScope = "essentials" | "recent" | "full";
 export interface BriefArgs {
   scope?: BriefScope;
   project_identifier?: string;
+  shared_only?: boolean;
 }
 
 // "Essentials" are the thought types that represent durable, reusable context.
@@ -52,18 +53,28 @@ export function handleGetBrief(
   }
 
   const slug = a.project_identifier;
+  // When shared_only is set (and no explicit project_identifier), all reads are
+  // restricted to visibility='shared' thoughts — the fail-safe path that prevents
+  // cross-project contamination when no project slug can be resolved.
+  const sharedOnly = a.shared_only === true && slug === undefined;
 
   const essentials: ThoughtSummary[] =
     scope === "essentials" || scope === "full"
-      ? fetchEssentials(db, slug)
+      ? sharedOnly ? fetchShared(db) : fetchEssentials(db, slug)
       : [];
   const recent: ThoughtSummary[] =
-    scope === "recent" || scope === "full" ? fetchRecent(db, slug) : [];
+    scope === "recent" || scope === "full"
+      ? fetchRecent(db, slug, sharedOnly)
+      : [];
 
   // Shared section: visibility='shared' thoughts across all projects.
   // Fetch before deduplication so we can filter shared ids out of the other sections.
+  // In shared-only mode, essentials already == fetchShared, so skip the separate fetch
+  // to avoid double-counting — we'll reuse the essentials array as the shared set.
   const shared: ThoughtSummary[] =
-    scope === "essentials" || scope === "full" ? fetchShared(db) : [];
+    scope === "essentials" || scope === "full"
+      ? sharedOnly ? [] : fetchShared(db)
+      : [];
 
   // Remove any thought that appears in the Shared section from Essentials and
   // Recent so each thought renders exactly once.
@@ -154,8 +165,18 @@ function fetchEssentials(
 function fetchRecent(
   db: ThoughtDatabase,
   slug: string | undefined,
+  sharedOnly = false,
 ): ThoughtSummary[] {
   const since = new Date(Date.now() - RECENT_WINDOW_MS).toISOString();
+  if (sharedOnly) {
+    // Shared-only fail-safe path: only return visibility='shared' thoughts.
+    const result = listThoughts(db.db, {
+      since,
+      shared_only: true,
+      limit: RECENT_LIMIT,
+    });
+    return result.results;
+  }
   // include_shared is false here — the Shared section owns shared rows so they
   // don't appear in both sections.
   const result = listThoughts(db.db, {

--- a/src/tools/context.ts
+++ b/src/tools/context.ts
@@ -31,6 +31,7 @@ export interface SelectContextArgs {
   include_brief?: boolean;
   include_stats?: boolean;
   limit?: number;
+  shared_only?: boolean;
 }
 
 export function handleSelectContext(
@@ -54,6 +55,11 @@ export function handleSelectContext(
   }
 
   const limit = clampLimit(a.limit);
+  // When shared_only is set (and no explicit project_identifier), all reads are
+  // restricted to visibility='shared' thoughts — the fail-safe that prevents
+  // cross-project contamination when no project slug can be resolved.
+  // Mirrors the pattern in brief.ts:59.
+  const sharedOnly = a.shared_only === true && a.project_identifier === undefined;
   const sections: string[] = [];
 
   // Optional brief header. We reuse get_brief to avoid forking the essentials
@@ -63,6 +69,7 @@ export function handleSelectContext(
     const briefResult = handleGetBrief(db, {
       scope: "essentials",
       project_identifier: a.project_identifier,
+      shared_only: sharedOnly,
     });
     if (!briefResult.isError) {
       try {
@@ -88,6 +95,7 @@ export function handleSelectContext(
     since: a.since,
     project_identifier: a.project_identifier,
     include_shared: a.include_shared,
+    shared_only: sharedOnly,
     limit,
   });
 
@@ -131,6 +139,7 @@ interface CollectArgs {
   since: string | undefined;
   project_identifier: string | undefined;
   include_shared: boolean | undefined;
+  shared_only: boolean;
   limit: number;
 }
 
@@ -150,6 +159,7 @@ function collectThoughts(
         since: args.since,
         project_identifier: args.project_identifier,
         include_shared: args.include_shared ?? true,
+        shared_only: args.shared_only,
         limit: args.limit,
       });
       pool.push(...result.results);
@@ -161,6 +171,7 @@ function collectThoughts(
       since: args.since,
       project_identifier: args.project_identifier,
       include_shared: args.include_shared ?? true,
+      shared_only: args.shared_only,
       limit: args.limit,
     });
     pool.push(...result.results);

--- a/tests/db/database.test.ts
+++ b/tests/db/database.test.ts
@@ -28,7 +28,7 @@ describe("ThoughtDatabase", () => {
 
   it("runs migrations to latest version", () => {
     db = new ThoughtDatabase(":memory:");
-    expect(db.getSchemaVersion()).toBe(6);
+    expect(db.getSchemaVersion()).toBe(7);
   });
 
   it("creates thoughts table", () => {
@@ -59,7 +59,7 @@ describe("ThoughtDatabase", () => {
     db = new ThoughtDatabase(":memory:");
     // Simulate re-running migrations on same version
     const version = db.getSchemaVersion();
-    expect(version).toBe(6);
+    expect(version).toBe(7);
   });
 
   it("creates oauth_clients table after migration", () => {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import Database from "better-sqlite3";
 import { ThoughtDatabase } from "../../src/db/database.js";
-import { getSchemaVersion, runMigrations } from "../../src/db/migrations.js";
+import { getSchemaVersion, getMigrations, runMigrations, setSchemaVersion } from "../../src/db/migrations.js";
 
 describe("Migration v5 — version-stamp alignment with Shelby-MacOS", () => {
   let db: ThoughtDatabase;
@@ -14,8 +14,8 @@ describe("Migration v5 — version-stamp alignment with Shelby-MacOS", () => {
     db?.close();
   });
 
-  it("schema version is 6 after all migrations", () => {
-    expect(getSchemaVersion(db.db)).toBe(6);
+  it("schema version is 7 after all migrations", () => {
+    expect(getSchemaVersion(db.db)).toBe(7);
   });
 
   it("thoughts table has source_agent column", () => {
@@ -105,7 +105,7 @@ describe("migration v6 — project identity", () => {
     const db = new Database(":memory:");
     runMigrations(db);
 
-    expect(getSchemaVersion(db)).toBe(6);
+    expect(getSchemaVersion(db)).toBe(7);
 
     const thoughtCols = db.prepare("PRAGMA table_info(thoughts)").all() as Array<{ name: string }>;
     expect(thoughtCols.map((c) => c.name)).toContain("project_identifier");
@@ -115,5 +115,24 @@ describe("migration v6 — project identity", () => {
       expect.arrayContaining(["slug","display_name","member_repos","member_paths","provisional","created_at","updated_at"]),
     );
     db.close();
+  });
+});
+
+describe("migration v7 — normalize legacy display-name project_identifiers", () => {
+  it("v7 normalizes legacy display-name project_identifiers to slugs", () => {
+    const db = new Database(":memory:");
+    // Advance through v6 only, seed legacy rows, then let runMigrations apply v7 to them.
+    for (const m of getMigrations().filter((x) => x.version <= 6)) m.up(db);
+    setSchemaVersion(db, 6);
+    const now = new Date().toISOString();
+    const ins = db.prepare("INSERT INTO thoughts (id, content, type, source, created_at, updated_at, project_identifier) VALUES (?,?,?,?,?,?,?)");
+    ins.run("a", "x", "note", "t", now, now, "Shelby");
+    ins.run("b", "y", "note", "t", now, now, "The Crooked Line");
+    ins.run("c", "z", "note", "t", now, now, "");
+    runMigrations(db); // applies v7 only
+    const get = db.prepare("SELECT project_identifier AS p FROM thoughts WHERE id = ?");
+    expect((get.get("a") as any).p).toBe("shelby");
+    expect((get.get("b") as any).p).toBe("the-crooked-line");
+    expect((get.get("c") as any).p).toBeNull();
   });
 });

--- a/tests/db/projects.test.ts
+++ b/tests/db/projects.test.ts
@@ -5,6 +5,7 @@ import {
   upsertProject,
   getProjectBySlug,
   findProjectByRepo,
+  findProjectByPath,
   listProjects,
   normalizeGitRemote,
 } from "../../src/db/projects.js";
@@ -45,5 +46,22 @@ describe("projects registry", () => {
     const p = getProjectBySlug(db, "x");
     expect(p?.displayName).toBe("X2");
     expect(p?.provisional).toBe(false);
+  });
+});
+
+describe("findProjectByPath", () => {
+  it("matches the project whose member_path is the longest prefix of dir", () => {
+    upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: ["/Users/tim/Projects/Shelby"], provisional: false });
+    upsertProject(db, { slug: "tcl", displayName: "TCL", memberRepos: [], memberPaths: ["/Users/tim/Projects/The Crooked Line"], provisional: false });
+
+    expect(findProjectByPath(db, "/Users/tim/Projects/Shelby")?.slug).toBe("shelby");
+    expect(findProjectByPath(db, "/Users/tim/Projects/Shelby/Shelby-MCP/src")?.slug).toBe("shelby");
+    expect(findProjectByPath(db, "/Users/tim/Projects/Other")).toBeNull();
+  });
+
+  it("prefers the longest matching member_path when paths nest", () => {
+    upsertProject(db, { slug: "outer", displayName: "Outer", memberRepos: [], memberPaths: ["/Users/tim/Projects"], provisional: false });
+    upsertProject(db, { slug: "inner", displayName: "Inner", memberRepos: [], memberPaths: ["/Users/tim/Projects/Shelby"], provisional: false });
+    expect(findProjectByPath(db, "/Users/tim/Projects/Shelby/x")?.slug).toBe("inner");
   });
 });

--- a/tests/db/resolve-project.test.ts
+++ b/tests/db/resolve-project.test.ts
@@ -98,4 +98,12 @@ describe("currentProjectSlug (read-only)", () => {
     expect(slug).toBeNull();
     expect(listProjects(db).length).toBe(countBefore);
   });
+
+  it("resolves a markerless container dir via the registry member_paths", () => {
+    // No .git / package.json marker here — only a registry path match.
+    const dir = mkdtempSync(join(tmpdir(), "container-"));
+    upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: [dir], provisional: false });
+    expect(currentProjectSlug(db, dir)).toBe("shelby");        // read path
+    expect(resolveProjectIdentifier(db, dir)).toBe("shelby");  // write path
+  });
 });

--- a/tests/db/seed.test.ts
+++ b/tests/db/seed.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import Database from "better-sqlite3";
+import { runMigrations } from "../../src/db/migrations.js";
+import { listProjects, getProjectBySlug, upsertProject } from "../../src/db/projects.js";
+import { ensureSeedProjects } from "../../src/db/seed.js";
+
+let db: Database.Database;
+beforeEach(() => { db = new Database(":memory:"); runMigrations(db); });
+
+describe("ensureSeedProjects", () => {
+  it("seeds known projects into an empty registry", () => {
+    ensureSeedProjects(db);
+    expect(getProjectBySlug(db, "shelby")?.memberPaths.length).toBeGreaterThan(0);
+    expect(listProjects(db).length).toBeGreaterThanOrEqual(4);
+  });
+
+  it("does not clobber a human-confirmed (non-provisional, edited) project", () => {
+    upsertProject(db, { slug: "shelby", displayName: "My Shelby", memberRepos: ["x"], memberPaths: ["/custom"], provisional: false });
+    ensureSeedProjects(db);
+    expect(getProjectBySlug(db, "shelby")?.displayName).toBe("My Shelby");
+  });
+});

--- a/tests/integrity/project-repair.test.ts
+++ b/tests/integrity/project-repair.test.ts
@@ -33,6 +33,12 @@ describe("repair classification", () => {
     expect(report.flagged.some((i) => i.id === id)).toBe(true);
     expect(report.highConfidence.some((i) => i.id === id)).toBe(false);
   });
+  it("high-confidence by distinctive source string", () => {
+    const id = insertThought(db, { content: "x", source: "deep-dive-graphify-techniques-for-shelby" });
+    const report = planProjectRepairs(db);
+    const item = report.highConfidence.find((i) => i.id === id);
+    expect(item?.suggestedSlug).toBe("shelby");
+  });
   it("ignores already-resolved thoughts", () => {
     const id = insertThought(db, { content: "ok", project_identifier: "shelby" });
     const report = planProjectRepairs(db);

--- a/tests/mcp/resolve-dir.test.ts
+++ b/tests/mcp/resolve-dir.test.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from "vitest";
+import { pickResolutionDir } from "../../src/mcp/resolve-dir.js";
+
+describe("pickResolutionDir", () => {
+  it("prefers the first file:// client root over the fallback cwd", () => {
+    expect(pickResolutionDir([{ uri: "file:///Users/tim/Projects/Shelby" }], "/")).toBe("/Users/tim/Projects/Shelby");
+  });
+  it("falls back to cwd when there are no roots", () => {
+    expect(pickResolutionDir([], "/fallback")).toBe("/fallback");
+    expect(pickResolutionDir(undefined, "/fallback")).toBe("/fallback");
+  });
+  it("ignores non-file roots", () => {
+    expect(pickResolutionDir([{ uri: "https://example.com" }], "/fallback")).toBe("/fallback");
+  });
+});

--- a/tests/mcp/scope-defaults.test.ts
+++ b/tests/mcp/scope-defaults.test.ts
@@ -94,15 +94,10 @@ describe("applyDefaultScope", () => {
     expect(result.include_shared).toBe(false);
   });
 
-  it("returns args unchanged (no project_identifier) when cwd is a non-project directory", () => {
-    const cwd = plainDir();
-    const args = { query: "hello" };
-
-    const result = applyDefaultScope(args, db, cwd);
-
-    // No slug resolved → no injection
+  it("falls back to shared-only (never global) when cwd does not resolve", () => {
+    const result = applyDefaultScope({ query: "hello" }, db, plainDir());
     expect(result.project_identifier).toBeUndefined();
-    // No mutation
+    expect(result.shared_only).toBe(true);   // new fail-safe
     expect(result.query).toBe("hello");
   });
 

--- a/tests/tools/brief.test.ts
+++ b/tests/tools/brief.test.ts
@@ -140,6 +140,17 @@ describe("handleGetBrief", () => {
   });
 });
 
+describe("get_brief shared_only fail-safe", () => {
+  it("returns a shared-only brief when no project resolves", () => {
+    capture("Project A decision", { type: "decision", project_identifier: "a", summary: "Project A decision" });
+    capture("A user fact about Tim", { type: "reference", visibility: "shared", summary: "A user fact about Tim" });
+    const result = handleGetBrief(db, { shared_only: true });
+    const data = parseResult(result);
+    expect(data.brief).toContain("A user fact about Tim");
+    expect(data.brief).not.toContain("Project A decision");
+  });
+});
+
 describe("get_brief slug scoping", () => {
   it("includes current slug + shared, excludes other projects, labels Shared", () => {
     insertThought(db.db, { content: "shelby decision", type: "decision", summary: "shelby decision", project_identifier: "shelby" });

--- a/tests/tools/context.test.ts
+++ b/tests/tools/context.test.ts
@@ -158,6 +158,58 @@ describe("handleSelectContext", () => {
     expect(data.document).not.toContain("Kuow slug thought");
   });
 
+  it("shared_only: returns only shared thoughts, excludes all project-scoped thoughts", () => {
+    // A personal decision in project "a" — must NOT leak
+    capture("Project A private decision", {
+      project_identifier: "project-a",
+      type: "decision",
+      summary: "Project A private decision",
+    });
+    // A personal note in project "b" — must NOT leak
+    capture("Project B private note", {
+      project_identifier: "project-b",
+      type: "note",
+      summary: "Project B private note",
+    });
+    // A shared reference — MUST appear
+    capture("Shared reference", {
+      visibility: "shared",
+      type: "reference",
+      summary: "Shared reference",
+    });
+
+    const result = handleSelectContext(db, { shared_only: true });
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result);
+
+    expect(data.matched_count).toBe(1);
+    expect(data.document).toContain("Shared reference");
+    expect(data.document).not.toContain("Project A private decision");
+    expect(data.document).not.toContain("Project B private note");
+  });
+
+  it("shared_only with include_brief: brief header is also shared-only (no cross-project leak)", () => {
+    // A decision in project "a" that would appear in a normal brief — must NOT leak via the brief header
+    capture("Project A critical decision", {
+      project_identifier: "project-a",
+      type: "decision",
+      summary: "Project A critical decision",
+    });
+    // A shared decision that SHOULD appear in the brief header
+    capture("Shared critical decision", {
+      visibility: "shared",
+      type: "decision",
+      summary: "Shared critical decision",
+    });
+
+    const result = handleSelectContext(db, { shared_only: true, include_brief: true });
+    expect(result.isError).toBeUndefined();
+    const data = parseResult(result);
+
+    expect(data.document).not.toContain("Project A critical decision");
+    expect(data.document).toContain("Shared critical decision");
+  });
+
   it("rejects non-string-array types", () => {
     const result = handleSelectContext(db, { types: [1, 2, 3] as unknown as string[] });
     expect(result.isError).toBe(true);


### PR DESCRIPTION
## Summary
Makes the TS memory server resolve projects **registry-first** so captures stop orphaning to NULL and reads stop leaking across projects. Mirrors the Swift side (Studio-Moser/Shelby-MacOS `feat/memory-scoping-self-heal`); **merge-gated together per ADR 0001** (Studio-Moser/Shelby-Strategy).

- `findProjectByPath` longest-prefix registry lookup → `detectSlug` registry-first
- `ensureSeedProjects` on init; migration **v7** normalizes legacy display-name identifiers → slugs
- Read **fail-safe to shared-only** when unresolved (never global) across search/list/brief/**select_context**
- MCP **roots** capability — resolve the caller's dir from the client, not `process.cwd()`
- Repair: source-prefix inference

## Test Plan
- [x] `npm run check` (tsc + eslint) clean
- [x] `npm test` — 434 passing
- [ ] Reviewer: confirm orphan-hidden / shared-only invariant on all read tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)