### PR TITLE
Depersonalize MCP twin: externalize seed, generic routing, neutral examples (#308, #309, #310)

### DIFF
--- a/skills/shelby-forage/SKILL.md
+++ b/skills/shelby-forage/SKILL.md
@@ -102,7 +102,7 @@ Find *actionable* tasks that may have been forgotten. The goal is to surface thi
 
 1. Use `list_thoughts` with `type: "task"` and `until` set to 14 days ago to find older tasks
 2. For each, read the content via `get_thought` and assess whether it's actually stale:
-   - **Flag it** if it reads like a one-off action item that was never completed (e.g., "fix the login bug", "email Tim about the deploy", "update the staging config")
+   - **Flag it** if it reads like a one-off action item that was never completed (e.g., "fix the login bug", "email the team about the deploy", "update the staging config")
    - **Skip it** if it's a standing practice, ongoing guideline, or reference (e.g., "always use ESM imports", "run tests before merging", "prefer composition over inheritance"). These aren't stale — they're meant to persist.
    - **Skip it** if it has a `consolidated_into` value (already handled)
    - **Skip it** if it has recent edges linking it to other thoughts (it's being actively referenced)

--- a/skills/shelby-onboard/SKILL.md
+++ b/skills/shelby-onboard/SKILL.md
@@ -37,7 +37,7 @@ Ask about:
 **Capture as:**
 - Type: `reference` — these are stable facts about the person
 - Topics: `["identity"]` plus anything specific (e.g., `["identity", "ios", "startup"]`)
-- Summary: one-line distillation (e.g., "Tim is a senior iOS engineer and solo founder building Shelby, based in Austin")
+- Summary: one-line distillation (e.g., "a senior iOS engineer and solo founder building a productivity app, based in a mid-size city")
 
 ### Round 2: What Are You Working On?
 

--- a/src/cli/forage.ts
+++ b/src/cli/forage.ts
@@ -76,7 +76,7 @@ Find *actionable* tasks that may have been forgotten. The goal is to surface thi
 
 1. Use \`list_thoughts\` with \`type: "task"\` and \`until\` set to 14 days ago to find older tasks
 2. For each, read the content via \`get_thought\` and assess whether it's actually stale:
-   - **Flag it** if it reads like a one-off action item that was never completed (e.g., "fix the login bug", "email Tim about the deploy", "update the staging config")
+   - **Flag it** if it reads like a one-off action item that was never completed (e.g., "fix the login bug", "email the team about the deploy", "update the staging config")
    - **Skip it** if it's a standing practice, ongoing guideline, or reference (e.g., "always use ESM imports", "run tests before merging", "prefer composition over inheritance"). These aren't stale — they're meant to persist.
    - **Skip it** if it has a \`consolidated_into\` value (already handled)
    - **Skip it** if it has recent edges linking it to other thoughts (it's being actively referenced)

--- a/src/cli/repair-projects.ts
+++ b/src/cli/repair-projects.ts
@@ -1,5 +1,6 @@
 import { ThoughtDatabase } from "../db/database.js";
 import { repairProjects, type RepairReport } from "../integrity/project-repair.js";
+import { loadProjectSeed, toProjects, sourceAliasMap } from "../integrity/project-seed.js";
 
 /**
  * Pure formatter for a RepairReport.  All output logic lives here so it can be
@@ -62,7 +63,14 @@ export function formatRepairReport(report: RepairReport, apply: boolean): string
 export function runRepairProjects(dbPath: string, apply: boolean): void {
   const db = new ThoughtDatabase(dbPath);
   try {
-    const report = repairProjects(db.db, { apply });
+    // Inject the per-user seed (#308/#309) — empty on a fresh install.
+    const seed = loadProjectSeed();
+    const report = repairProjects(db.db, {
+      apply,
+      projects: toProjects(seed),
+      topicClusters: seed.topicClusters,
+      sourceAliases: sourceAliasMap(seed),
+    });
     const output = formatRepairReport(report, apply);
     console.error(output);
   } finally {

--- a/src/integrity/project-repair.ts
+++ b/src/integrity/project-repair.ts
@@ -61,18 +61,31 @@ function inferByTopics(topics: string[], topicClusters: Record<string, string>):
   return { slug: null, ambiguous: false };
 }
 
-/** Map a capture source/source_agent string to a slug when it unambiguously names one project. */
-function inferBySource(source: string | null): string | null {
+/**
+ * Map a capture source string to a slug using the registry-derived source-alias
+ * map (#309) instead of a hardcoded ladder of one developer's project names.
+ * With no configured aliases this returns null — a fresh install makes no
+ * source-based assignment. Match order is deterministic: longest alias first
+ * (more specific wins), then lexicographic.
+ */
+function inferBySource(source: string | null, aliases: Record<string, string>): string | null {
   if (!source) return null;
+  const keys = Object.keys(aliases);
+  if (keys.length === 0) return null;
   const s = source.toLowerCase();
-  if (s.includes("shelby") || s.includes("graphify")) return "shelby";
-  if (s.includes("crooked") || s.includes("tcl") || s.includes("gdelt") || s.includes("polymarket")) return "the-crooked-line";
-  if (s.includes("ausra")) return "ausra-photos";
-  if (s.includes("kuow")) return "kuow-games";
+  keys.sort((a, b) => (a.length !== b.length ? b.length - a.length : a < b ? -1 : 1));
+  for (const alias of keys) {
+    if (s.includes(alias)) return aliases[alias] ?? null;
+  }
   return null;
 }
 
-function classify(t: { id: string; project: string | null; topics: string[]; source: string | null }, projects: Project[], topicClusters: Record<string, string>): RepairItem {
+function classify(
+  t: { id: string; project: string | null; topics: string[]; source: string | null },
+  projects: Project[],
+  topicClusters: Record<string, string>,
+  sourceAliases: Record<string, string>,
+): RepairItem {
   const byPath = inferByPath(t.project, projects);
   if (byPath) {
     return {
@@ -91,7 +104,7 @@ function classify(t: { id: string; project: string | null; topics: string[]; sou
       reason: `distinctive topic → ${byTopic.slug}`,
     };
   }
-  const bySource = inferBySource(t.source);
+  const bySource = inferBySource(t.source, sourceAliases);
   if (bySource) {
     return {
       id: t.id,
@@ -146,14 +159,18 @@ function parseJsonArrayRaw(raw: string | null): string[] {
   }
 }
 
-export function planProjectRepairs(db: Database.Database, topicClusters: Record<string, string> = DEFAULT_TOPIC_CLUSTERS): RepairReport {
+export function planProjectRepairs(
+  db: Database.Database,
+  topicClusters: Record<string, string> = DEFAULT_TOPIC_CLUSTERS,
+  sourceAliases: Record<string, string> = {},
+): RepairReport {
   const projects = listProjects(db);
   const highConfidence: RepairItem[] = [];
   const flagged: RepairItem[] = [];
   let scanned = 0;
   for (const t of repairCandidates(db)) {
     scanned++;
-    const item = classify(t, projects, topicClusters);
+    const item = classify(t, projects, topicClusters, sourceAliases);
     if (item.confidence === "high") highConfidence.push(item);
     else flagged.push(item);
   }
@@ -162,12 +179,20 @@ export function planProjectRepairs(db: Database.Database, topicClusters: Record<
 
 export function repairProjects(
   db: Database.Database,
-  opts: { apply: boolean; projects?: Project[]; topicClusters?: Record<string, string> },
+  opts: {
+    apply: boolean;
+    projects?: Project[];
+    topicClusters?: Record<string, string>;
+    sourceAliases?: Record<string, string>;
+  },
 ): RepairReport {
+  // Defaults are EMPTY (#308/#309): no bundled projects/topics/aliases. The
+  // production caller (cli/repair-projects) injects the per-user seed.
   const projects = opts.projects ?? DEFAULT_KNOWN_PROJECTS;
   const topicClusters = opts.topicClusters ?? DEFAULT_TOPIC_CLUSTERS;
+  const sourceAliases = opts.sourceAliases ?? {};
   seedKnownProjects(db, projects);
-  const report = planProjectRepairs(db, topicClusters);
+  const report = planProjectRepairs(db, topicClusters, sourceAliases);
   if (!opts.apply) return report;
 
   let applied = 0;

--- a/src/integrity/project-seed.ts
+++ b/src/integrity/project-seed.ts
@@ -1,0 +1,77 @@
+// Per-user project seed (#308). Mirrors the Shelby-MacOS `ProjectSeed` type
+// (ADR-0001 parity). Replaces the formerly bundled, hardcoded seed (one
+// developer's projects, `/Users/...` paths, ~26 personal topics) with config
+// loaded from `~/.shelbymcp/projects.seed.json`.
+//
+// The compiled-in default is EMPTY: a published package with no config seeds
+// zero projects, an empty topic-cluster map, and no source-routing aliases.
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Project } from "../db/projects.js";
+
+export interface SeedProject {
+  slug: string;
+  displayName: string;
+  memberRepos?: string[];
+  memberPaths?: string[];
+  provisional?: boolean;
+  /** Substrings that route a thought's `source` to this slug (#309). */
+  sourceAliases?: string[];
+}
+
+export interface ProjectSeed {
+  projects: SeedProject[];
+  topicClusters: Record<string, string>;
+}
+
+/** The compiled-in default: no bundled projects, topics, or aliases. */
+export const EMPTY_SEED: ProjectSeed = { projects: [], topicClusters: {} };
+
+/** Default per-user config location: `~/.shelbymcp/projects.seed.json`. */
+export function seedDefaultPath(): string {
+  return join(homedir(), ".shelbymcp", "projects.seed.json");
+}
+
+/**
+ * Load the seed from `path`. Returns `EMPTY_SEED` when the file is absent or
+ * unparseable — never throws, so a missing/corrupt config can't break server
+ * start.
+ */
+export function loadProjectSeed(path: string = seedDefaultPath()): ProjectSeed {
+  try {
+    if (!existsSync(path)) return EMPTY_SEED;
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (typeof parsed !== "object" || parsed === null) return EMPTY_SEED;
+    const obj = parsed as { projects?: unknown; topicClusters?: unknown };
+    const projects = Array.isArray(obj.projects) ? (obj.projects as SeedProject[]) : [];
+    const topicClusters =
+      typeof obj.topicClusters === "object" && obj.topicClusters !== null
+        ? (obj.topicClusters as Record<string, string>)
+        : {};
+    return { projects, topicClusters };
+  } catch {
+    return EMPTY_SEED;
+  }
+}
+
+/** Registry `Project` records for seeding the `projects` table. */
+export function toProjects(seed: ProjectSeed): Project[] {
+  return seed.projects.map((p) => ({
+    slug: p.slug,
+    displayName: p.displayName,
+    memberRepos: p.memberRepos ?? [],
+    memberPaths: p.memberPaths ?? [],
+    provisional: p.provisional ?? false,
+  }));
+}
+
+/** Flattened `lowercased-alias → slug` map used by source inference (#309). */
+export function sourceAliasMap(seed: ProjectSeed): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const p of seed.projects) {
+    for (const alias of p.sourceAliases ?? []) map[alias.toLowerCase()] = p.slug;
+  }
+  return map;
+}

--- a/src/integrity/project-seed.ts
+++ b/src/integrity/project-seed.ts
@@ -34,10 +34,49 @@ export function seedDefaultPath(): string {
   return join(homedir(), ".shelbymcp", "projects.seed.json");
 }
 
+function isStringArray(v: unknown): v is string[] {
+  return Array.isArray(v) && v.every((x) => typeof x === "string");
+}
+
+/** Validate one raw project entry. Returns null if it is malformed. */
+function parseSeedProject(raw: unknown): SeedProject | null {
+  if (typeof raw !== "object" || raw === null) return null;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.slug !== "string" || typeof o.displayName !== "string") return null;
+  if (o.memberRepos !== undefined && !isStringArray(o.memberRepos)) return null;
+  if (o.memberPaths !== undefined && !isStringArray(o.memberPaths)) return null;
+  if (o.sourceAliases !== undefined && !isStringArray(o.sourceAliases)) return null;
+  if (o.provisional !== undefined && typeof o.provisional !== "boolean") return null;
+  return {
+    slug: o.slug,
+    displayName: o.displayName,
+    memberRepos: o.memberRepos as string[] | undefined,
+    memberPaths: o.memberPaths as string[] | undefined,
+    provisional: o.provisional as boolean | undefined,
+    sourceAliases: o.sourceAliases as string[] | undefined,
+  };
+}
+
+/** Validate the topic-cluster map. Returns null if any value is not a string. */
+function parseTopicClusters(raw: unknown): Record<string, string> | null {
+  if (raw === undefined) return {};
+  if (typeof raw !== "object" || raw === null) return null;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (typeof v !== "string") return null;
+    out[k] = v;
+  }
+  return out;
+}
+
 /**
- * Load the seed from `path`. Returns `EMPTY_SEED` when the file is absent or
- * unparseable — never throws, so a missing/corrupt config can't break server
- * start.
+ * Load the seed from `path`. Returns `EMPTY_SEED` when the file is absent,
+ * unparseable, or **malformed** — never throws, so a missing/corrupt config
+ * can't break server start. Validation is strict and whole-file (mirrors the
+ * Swift `ProjectSeed` Codable): any project entry missing a string
+ * `slug`/`displayName`, any mistyped member field, or any non-string topic
+ * value rejects the entire config to `EMPTY_SEED` — so no phantom rows reach
+ * the registry.
  */
 export function loadProjectSeed(path: string = seedDefaultPath()): ProjectSeed {
   try {
@@ -45,11 +84,19 @@ export function loadProjectSeed(path: string = seedDefaultPath()): ProjectSeed {
     const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
     if (typeof parsed !== "object" || parsed === null) return EMPTY_SEED;
     const obj = parsed as { projects?: unknown; topicClusters?: unknown };
-    const projects = Array.isArray(obj.projects) ? (obj.projects as SeedProject[]) : [];
-    const topicClusters =
-      typeof obj.topicClusters === "object" && obj.topicClusters !== null
-        ? (obj.topicClusters as Record<string, string>)
-        : {};
+
+    const rawProjects = obj.projects === undefined ? [] : obj.projects;
+    if (!Array.isArray(rawProjects)) return EMPTY_SEED;
+    const projects: SeedProject[] = [];
+    for (const raw of rawProjects) {
+      const project = parseSeedProject(raw);
+      if (project === null) return EMPTY_SEED; // strict: reject the whole file
+      projects.push(project);
+    }
+
+    const topicClusters = parseTopicClusters(obj.topicClusters);
+    if (topicClusters === null) return EMPTY_SEED;
+
     return { projects, topicClusters };
   } catch {
     return EMPTY_SEED;

--- a/src/integrity/seed-data.ts
+++ b/src/integrity/seed-data.ts
@@ -1,78 +1,12 @@
-// OPERATOR BOOTSTRAP DATA — contains machine-specific paths + a hand-curated topic map.
-// TODO before npm publish: load this from ~/.shelbymcp/projects.seed.json (or a --seed flag)
-// instead of bundling, so the published package ships no literal home paths.
+// The project seed is no longer bundled. It loads per-user from
+// `~/.shelbymcp/projects.seed.json` via `project-seed.ts` (#308); a published
+// package with no config seeds nothing. These exports remain as EMPTY defaults
+// so callers that don't inject a seed contribute no projects/topics.
 
 import type { Project } from "../db/projects.js";
 
-// Known projects seed. member_repos are normalized git remotes; member_paths are
-// machine-local hints (used to map legacy absolute-path `project` values to slugs).
-export const DEFAULT_KNOWN_PROJECTS: Project[] = [
-  {
-    slug: "shelby",
-    displayName: "Shelby",
-    provisional: false,
-    memberRepos: [
-      "github.com/Studio-Moser/Shelby-MCP",
-      "github.com/Studio-Moser/Shelby-MacOS",
-      "github.com/Studio-Moser/Shelby-Strategy",
-      "github.com/Studio-Moser/Shelby-Docs",
-      "github.com/Studio-Moser/Shelby-Website",
-    ],
-    memberPaths: ["/Users/timmoser/Projects/Shelby"],
-  },
-  {
-    slug: "kuow-games",
-    displayName: "KUOW Games",
-    provisional: false,
-    memberRepos: [],
-    memberPaths: [
-      "/Users/timmoser/Projects/KUOW-Games",
-      "/Users/timmoser/Projects/KUOW-Core",
-      "/Users/timmoser/Projects/KUOW-Connect",
-      "/Users/timmoser/Projects/KUOW-Website",
-    ],
-  },
-  {
-    slug: "the-crooked-line",
-    displayName: "The Crooked Line",
-    provisional: false,
-    memberRepos: ["github.com/The-Crooked-Line/website"],
-    memberPaths: ["/Users/timmoser/Projects/The Crooked Line"],
-  },
-  {
-    slug: "ausra-photos",
-    displayName: "Ausra Photos",
-    provisional: false,
-    memberRepos: [],
-    memberPaths: ["/Users/timmoser/Projects/Ausra Photos"],
-  },
-];
+/** Empty by default — real projects load from the per-user seed config. */
+export const DEFAULT_KNOWN_PROJECTS: Project[] = [];
 
-// Distinctive topic → slug. Only topics that unambiguously identify a project.
-export const DEFAULT_TOPIC_CLUSTERS: Record<string, string> = {
-  "kuow-games": "kuow-games",
-  "foggy-find": "kuow-games",
-  "game-shell": "kuow-games",
-  "game-takeover": "kuow-games",
-  "player-progress": "kuow-games",
-  "daily-puzzle-pipeline": "kuow-games",
-  "overnight-worker": "the-crooked-line",
-  "polymarket": "the-crooked-line",
-  "prediction-market": "the-crooked-line",
-  "prediction-markets": "the-crooked-line",
-  "cftc": "the-crooked-line",
-  "sec-edgar": "the-crooked-line",
-  "market-manipulation": "the-crooked-line",
-  "government-contracts": "the-crooked-line",
-  "congressional-trading": "the-crooked-line",
-  "unusual-whales": "the-crooked-line",
-  "the-crooked-line": "the-crooked-line",
-  "ausra-photos": "ausra-photos",
-  "ausra-research": "ausra-photos",
-  "shelby-daily-research": "shelby",
-  "shelby-macos": "shelby",
-  "shelby-mcp": "shelby",
-  "shelby-strategy": "shelby",
-  "shelby-research": "shelby",
-  "shelby-mac-ui": "shelby",
-};
+/** Empty by default — real topic clusters load from the per-user seed config. */
+export const DEFAULT_TOPIC_CLUSTERS: Record<string, string> = {};

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -20,6 +20,7 @@ import { applyDefaultScope } from "./scope-defaults.js";
 import { pickResolutionDir } from "./resolve-dir.js";
 import type { RootRef } from "./resolve-dir.js";
 import { ensureSeedProjects } from "../db/seed.js";
+import { loadProjectSeed, toProjects } from "../integrity/project-seed.js";
 import {
   MAX_CONTENT_LENGTH,
   MAX_SUMMARY_LENGTH,
@@ -51,8 +52,9 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
     version: VERSION,
   });
 
-  // Seed the project registry so resolution can match known paths.
-  ensureSeedProjects(db.db);
+  // Seed the project registry from the per-user config (#308) so resolution can
+  // match known paths. Empty on a fresh install — nothing bundled.
+  ensureSeedProjects(db.db, toProjects(loadProjectSeed()));
 
   // ---------------------------------------------------------------------------
   // Client roots — used to resolve the caller's working directory.

--- a/tests/db/seed.test.ts
+++ b/tests/db/seed.test.ts
@@ -1,22 +1,40 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import Database from "better-sqlite3";
 import { runMigrations } from "../../src/db/migrations.js";
-import { listProjects, getProjectBySlug, upsertProject } from "../../src/db/projects.js";
+import { listProjects, getProjectBySlug, upsertProject, type Project } from "../../src/db/projects.js";
 import { ensureSeedProjects } from "../../src/db/seed.js";
 
 let db: Database.Database;
-beforeEach(() => { db = new Database(":memory:"); runMigrations(db); });
+beforeEach(() => {
+  db = new Database(":memory:");
+  runMigrations(db);
+});
+
+// Neutral, depersonalized fixture seed (stands in for a user-authored
+// `~/.shelbymcp/projects.seed.json`). After #308 the seed is injected, not
+// bundled.
+const TEST_PROJECTS: Project[] = [
+  { slug: "shelby", displayName: "Shelby", memberRepos: ["github.com/example/shelby"], memberPaths: ["/p/shelby"], provisional: false },
+  { slug: "kuow-games", displayName: "KUOW Games", memberRepos: [], memberPaths: ["/p/kuow"], provisional: false },
+  { slug: "the-crooked-line", displayName: "The Crooked Line", memberRepos: [], memberPaths: ["/p/tcl"], provisional: false },
+  { slug: "ausra-photos", displayName: "Ausra Photos", memberRepos: [], memberPaths: ["/p/ausra"], provisional: false },
+];
 
 describe("ensureSeedProjects", () => {
-  it("seeds known projects into an empty registry", () => {
+  it("seeds nothing when no projects are injected (fresh install, #308)", () => {
     ensureSeedProjects(db);
+    expect(listProjects(db).length).toBe(0);
+  });
+
+  it("seeds injected projects into an empty registry", () => {
+    ensureSeedProjects(db, TEST_PROJECTS);
     expect(getProjectBySlug(db, "shelby")?.memberPaths.length).toBeGreaterThan(0);
-    expect(listProjects(db).length).toBeGreaterThanOrEqual(4);
+    expect(listProjects(db).length).toBe(4);
   });
 
   it("does not clobber a human-confirmed (non-provisional, edited) project", () => {
     upsertProject(db, { slug: "shelby", displayName: "My Shelby", memberRepos: ["x"], memberPaths: ["/custom"], provisional: false });
-    ensureSeedProjects(db);
+    ensureSeedProjects(db, TEST_PROJECTS);
     expect(getProjectBySlug(db, "shelby")?.displayName).toBe("My Shelby");
   });
 });

--- a/tests/integrity/project-repair.test.ts
+++ b/tests/integrity/project-repair.test.ts
@@ -3,59 +3,109 @@ import Database from "better-sqlite3";
 import { runMigrations } from "../../src/db/migrations.js";
 import { insertThought, getThought } from "../../src/db/thoughts.js";
 import { seedKnownProjects, planProjectRepairs, repairProjects } from "../../src/integrity/project-repair.js";
+import { getProjectBySlug, type Project } from "../../src/db/projects.js";
+
+// After #308/#309 the seed (projects, topic clusters, source aliases) is
+// injected, not bundled. Tests supply neutral, depersonalized fixture data.
+const TEST_PROJECTS: Project[] = [
+  { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: ["/p/shelby"], provisional: false },
+  { slug: "kuow-games", displayName: "KUOW Games", memberRepos: [], memberPaths: ["/p/kuow"], provisional: false },
+  { slug: "the-crooked-line", displayName: "The Crooked Line", memberRepos: [], memberPaths: ["/p/tcl"], provisional: false },
+  { slug: "ausra-photos", displayName: "Ausra Photos", memberRepos: [], memberPaths: ["/p/ausra"], provisional: false },
+];
+const TEST_TOPICS: Record<string, string> = {
+  "kuow-games": "kuow-games",
+  "foggy-find": "kuow-games",
+  "polymarket": "the-crooked-line",
+};
+const TEST_ALIASES: Record<string, string> = {
+  graphify: "shelby",
+  shelby: "shelby",
+  gdelt: "the-crooked-line",
+  ausra: "ausra-photos",
+};
 
 let db: Database.Database;
-beforeEach(() => { db = new Database(":memory:"); runMigrations(db); seedKnownProjects(db); });
+beforeEach(() => {
+  db = new Database(":memory:");
+  runMigrations(db);
+  seedKnownProjects(db, TEST_PROJECTS);
+});
 
 describe("seedKnownProjects", () => {
-  it("registers the known projects idempotently", () => {
-    seedKnownProjects(db); // second call
-    const slugs = ["shelby", "kuow-games", "the-crooked-line", "ausra-photos"];
-    for (const s of slugs) expect(getProjectBySlugSafe(db, s)).toBe(true);
+  it("registers the injected projects idempotently", () => {
+    seedKnownProjects(db, TEST_PROJECTS); // second call
+    for (const s of ["shelby", "kuow-games", "the-crooked-line", "ausra-photos"]) {
+      expect(getProjectBySlug(db, s) !== null).toBe(true);
+    }
+  });
+
+  it("seeds nothing with no injected projects (fresh install, #308)", () => {
+    const fresh = new Database(":memory:");
+    runMigrations(fresh);
+    seedKnownProjects(fresh);
+    expect(getProjectBySlug(fresh, "shelby")).toBeNull();
   });
 });
 
 describe("repair classification", () => {
   it("high-confidence by distinctive topic", () => {
     const id = insertThought(db, { content: "x", topics: ["kuow-games", "foggy-find"] });
-    const report = planProjectRepairs(db);
+    const report = planProjectRepairs(db, TEST_TOPICS, TEST_ALIASES);
     const item = report.highConfidence.find((i) => i.id === id);
     expect(item?.suggestedSlug).toBe("kuow-games");
   });
   it("high-confidence by legacy project path matching a member_path", () => {
-    const id = insertThought(db, { content: "y", project: "/Users/timmoser/Projects/The Crooked Line", topics: ["research-source"] });
-    const item = planProjectRepairs(db).highConfidence.find((i) => i.id === id);
+    const id = insertThought(db, { content: "y", project: "/p/tcl", topics: ["research-source"] });
+    const item = planProjectRepairs(db, TEST_TOPICS, TEST_ALIASES).highConfidence.find((i) => i.id === id);
     expect(item?.suggestedSlug).toBe("the-crooked-line");
   });
   it("flags ambiguous (generic topics only) for review", () => {
     const id = insertThought(db, { content: "z", topics: ["research-source", "competitive"] });
-    const report = planProjectRepairs(db);
+    const report = planProjectRepairs(db, TEST_TOPICS, TEST_ALIASES);
     expect(report.flagged.some((i) => i.id === id)).toBe(true);
     expect(report.highConfidence.some((i) => i.id === id)).toBe(false);
   });
-  it("high-confidence by distinctive source string", () => {
+  it("high-confidence by distinctive source string (configured alias)", () => {
     const id = insertThought(db, { content: "x", source: "deep-dive-graphify-techniques-for-shelby" });
-    const report = planProjectRepairs(db);
+    const report = planProjectRepairs(db, TEST_TOPICS, TEST_ALIASES);
     const item = report.highConfidence.find((i) => i.id === id);
     expect(item?.suggestedSlug).toBe("shelby");
   });
   it("ignores already-resolved thoughts", () => {
     const id = insertThought(db, { content: "ok", project_identifier: "shelby" });
-    const report = planProjectRepairs(db);
+    const report = planProjectRepairs(db, TEST_TOPICS, TEST_ALIASES);
     expect([...report.highConfidence, ...report.flagged].some((i) => i.id === id)).toBe(false);
   });
 });
 
+describe("#309: source inference is registry-derived", () => {
+  it("makes no source-based assignment with no configured aliases", () => {
+    // A source the old hardcoded ladder routed to "shelby" must now fall through.
+    const id = insertThought(db, { content: "x", source: "deep-dive-graphify-techniques-for-shelby" });
+    const report = planProjectRepairs(db, TEST_TOPICS, {});
+    expect(report.highConfidence.some((i) => i.id === id)).toBe(false);
+    expect(report.flagged.some((i) => i.id === id)).toBe(true);
+  });
+});
+
 describe("apply", () => {
+  const opts = (apply: boolean) => ({
+    apply,
+    projects: TEST_PROJECTS,
+    topicClusters: TEST_TOPICS,
+    sourceAliases: TEST_ALIASES,
+  });
+
   it("dry-run writes nothing", () => {
     const id = insertThought(db, { content: "x", topics: ["kuow-games"] });
-    repairProjects(db, { apply: false });
+    repairProjects(db, opts(false));
     expect(getThought(db, id)?.project_identifier).toBeNull();
   });
   it("apply sets project_identifier + repaired_by for high-confidence, flags ambiguous", () => {
     const hi = insertThought(db, { content: "x", topics: ["polymarket"] });
     const amb = insertThought(db, { content: "z", topics: ["research-source"] });
-    const report = repairProjects(db, { apply: true });
+    const report = repairProjects(db, opts(true));
     expect(getThought(db, hi)?.project_identifier).toBe("the-crooked-line");
     expect(getThought(db, hi)?.metadata?.repaired_by).toBe("integrity-project-v1");
     expect(getThought(db, amb)?.project_identifier).toBeNull();
@@ -64,36 +114,25 @@ describe("apply", () => {
   });
   it("prior metadata keys survive repair (metadata merge check)", () => {
     const id = insertThought(db, { content: "x", topics: ["polymarket"], metadata: { prior_key: "prior_value" } });
-    repairProjects(db, { apply: true });
+    repairProjects(db, opts(true));
     const t = getThought(db, id);
     expect(t?.metadata?.repaired_by).toBe("integrity-project-v1");
     expect(t?.metadata?.prior_key).toBe("prior_value");
   });
-
   it("empty-string project_identifier gets repaired_from === 'empty'", () => {
-    // Insert a thought then manually set project_identifier to empty string
-    // (simulates a thought that was captured with project_identifier = "").
     const id = insertThought(db, { content: "x", topics: ["polymarket"] });
-    // Force empty string via raw SQL (insertThought defaults to null, not "")
     db.prepare("UPDATE thoughts SET project_identifier = '' WHERE id = ?").run(id);
-
-    repairProjects(db, { apply: true });
-    const t = getThought(db, id);
-    expect(t?.metadata?.repaired_from).toBe("empty");
+    repairProjects(db, opts(true));
+    expect(getThought(db, id)?.metadata?.repaired_from).toBe("empty");
   });
-
   it("null project_identifier gets repaired_from === 'null'", () => {
     const id = insertThought(db, { content: "x", topics: ["polymarket"] });
-    // insertThought defaults project_identifier to null
-    repairProjects(db, { apply: true });
-    const t = getThought(db, id);
-    expect(t?.metadata?.repaired_from).toBe("null");
+    repairProjects(db, opts(true));
+    expect(getThought(db, id)?.metadata?.repaired_from).toBe("null");
   });
-
   it("ambiguous repair writes needs_project_review and never ai_reviewed", () => {
-    // seed an ambiguous orphan: generic topics that map to no single project
     const id = insertThought(db, { content: "z", topics: ["research-source", "competitive"] });
-    repairProjects(db, { apply: true });
+    repairProjects(db, opts(true));
     const meta = getThought(db, id)?.metadata as Record<string, unknown>;
     expect(meta.needs_project_review).toBe(true);
     expect(meta.ai_reviewed).toBeUndefined();
@@ -105,23 +144,16 @@ describe("data injection", () => {
     const customDb = new Database(":memory:");
     runMigrations(customDb);
 
-    const customProject = {
+    const customProject: Project = {
       slug: "custom",
       displayName: "Custom",
-      memberRepos: [] as string[],
+      memberRepos: [],
       memberPaths: ["/tmp/x"],
       provisional: false,
     };
-    const customTopicClusters = { "widgets": "custom" };
-
-    repairProjects(customDb, {
-      apply: true,
-      projects: [customProject],
-      topicClusters: customTopicClusters,
-    });
+    const customTopicClusters = { widgets: "custom" };
 
     const id = insertThought(customDb, { content: "injection test", topics: ["widgets"] });
-    // The thought was inserted AFTER the initial repair pass, so run repair again
     repairProjects(customDb, {
       apply: true,
       projects: [customProject],
@@ -131,9 +163,3 @@ describe("data injection", () => {
     expect(getThought(customDb, id)?.project_identifier).toBe("custom");
   });
 });
-
-// helper
-import { getProjectBySlug } from "../../src/db/projects.js";
-function getProjectBySlugSafe(db: Database.Database, slug: string): boolean {
-  return getProjectBySlug(db, slug) !== null;
-}

--- a/tests/integrity/project-seed.test.ts
+++ b/tests/integrity/project-seed.test.ts
@@ -66,6 +66,38 @@ describe("loadProjectSeed", () => {
     }
   });
 
+  it("rejects the whole file to EMPTY when a project entry lacks a string slug", () => {
+    // Parity with Swift's strict Codable: any malformed element → EMPTY (so no
+    // phantom NULL-slug rows reach the registry).
+    const p = tmpPath();
+    writeFileSync(p, JSON.stringify({ projects: [{ displayName: "X" }] }));
+    try {
+      expect(loadProjectSeed(p)).toEqual(EMPTY_SEED);
+    } finally {
+      rmSync(p, { force: true });
+    }
+  });
+
+  it("rejects the whole file to EMPTY when a topicCluster value is not a string", () => {
+    const p = tmpPath();
+    writeFileSync(p, JSON.stringify({ topicClusters: { x: 123 } }));
+    try {
+      expect(loadProjectSeed(p)).toEqual(EMPTY_SEED);
+    } finally {
+      rmSync(p, { force: true });
+    }
+  });
+
+  it("rejects the whole file to EMPTY when a member field is mistyped", () => {
+    const p = tmpPath();
+    writeFileSync(p, JSON.stringify({ projects: [{ slug: "x", displayName: "X", memberPaths: "not-an-array" }] }));
+    try {
+      expect(loadProjectSeed(p)).toEqual(EMPTY_SEED);
+    } finally {
+      rmSync(p, { force: true });
+    }
+  });
+
   it("defaults optional project fields when omitted", () => {
     const p = tmpPath();
     writeFileSync(p, JSON.stringify({ projects: [{ slug: "x", displayName: "X" }] }));

--- a/tests/integrity/project-seed.test.ts
+++ b/tests/integrity/project-seed.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  loadProjectSeed,
+  toProjects,
+  sourceAliasMap,
+  EMPTY_SEED,
+} from "../../src/integrity/project-seed.js";
+
+// #308: the project seed loads from a per-user config and defaults to EMPTY
+// (no bundled projects/paths/topics) when the file is absent.
+
+function tmpPath(): string {
+  return join(tmpdir(), `seed-${Math.random().toString(36).slice(2)}.json`);
+}
+
+describe("loadProjectSeed", () => {
+  it("returns EMPTY_SEED when the file is absent", () => {
+    const seed = loadProjectSeed(tmpPath());
+    expect(seed).toEqual(EMPTY_SEED);
+    expect(seed.projects).toEqual([]);
+    expect(seed.topicClusters).toEqual({});
+    expect(sourceAliasMap(seed)).toEqual({});
+  });
+
+  it("returns EMPTY_SEED on malformed JSON", () => {
+    const p = tmpPath();
+    writeFileSync(p, "{ not valid json");
+    try {
+      expect(loadProjectSeed(p)).toEqual(EMPTY_SEED);
+    } finally {
+      rmSync(p, { force: true });
+    }
+  });
+
+  it("loads projects, topicClusters, and lowercased source aliases", () => {
+    const p = tmpPath();
+    writeFileSync(
+      p,
+      JSON.stringify({
+        projects: [
+          {
+            slug: "shelby",
+            displayName: "Shelby",
+            memberPaths: ["/p/shelby"],
+            sourceAliases: ["shelby", "Graphify"],
+          },
+        ],
+        topicClusters: { polymarket: "the-crooked-line" },
+      }),
+    );
+    try {
+      const seed = loadProjectSeed(p);
+      expect(seed.projects).toHaveLength(1);
+      expect(seed.projects[0]?.slug).toBe("shelby");
+      expect(seed.topicClusters.polymarket).toBe("the-crooked-line");
+      expect(toProjects(seed)[0]?.memberPaths).toEqual(["/p/shelby"]);
+
+      const aliases = sourceAliasMap(seed);
+      expect(aliases.shelby).toBe("shelby");
+      expect(aliases.graphify).toBe("shelby"); // lowercased
+    } finally {
+      rmSync(p, { force: true });
+    }
+  });
+
+  it("defaults optional project fields when omitted", () => {
+    const p = tmpPath();
+    writeFileSync(p, JSON.stringify({ projects: [{ slug: "x", displayName: "X" }] }));
+    try {
+      const projects = toProjects(loadProjectSeed(p));
+      expect(projects[0]?.memberRepos).toEqual([]);
+      expect(projects[0]?.memberPaths).toEqual([]);
+      expect(projects[0]?.provisional).toBe(false);
+    } finally {
+      rmSync(p, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
## What
Mirrors the Shelby-MacOS depersonalization (ADR-0001 parity) on the MCP twin.
- **#308:** Replace bundled `DEFAULT_KNOWN_PROJECTS` / `DEFAULT_TOPIC_CLUSTERS` (one developer's projects, `/Users/timmoser/...` paths, ~26 personal topics) with a per-user config loaded from `~/.shelbymcp/projects.seed.json` via a new `project-seed.ts`. Defaults are **EMPTY** — a published package seeds nothing. `server.ts` and the repair CLI load + inject the seed.
- **#309:** `inferBySource` is registry-derived — reads source→slug from each project's externalized `sourceAliases` (lowercased alias→slug map) instead of a hardcoded ladder. No configured aliases ⇒ no source assignment; deterministic longest-alias-first.
- **#310:** Neutralize personal examples — onboarding persona (`"Tim … Austin"` → name-free template) and the forage "email Tim" example (`forage.ts` + `SKILL.md`).

## Why
Part of epic #306. The MCP package is a distribution surface (npm); shipping one user's projects/paths/topics/identity misroutes other installs. Same config shape/location as the Swift app (`projects.seed.json`).

## Testing
- `npm run check` (tsc + eslint) → clean.
- `npm test` (vitest) → **442/442 passing** across 40 files. New `project-seed.test.ts` covers empty-default + config-present + aliases; migrated seed/repair tests inject neutral fixtures; new `#309` guard asserts no-alias ⇒ no source assignment.
- `grep -rn 'Tim\b|timmoser' src skills` → **0** matches.

Closes #310 · contributes the MCP half of #308 / #309 · Epic #306