### PR TITLE
fix(scope): harden MCP roots and project resolution

### DIFF
--- a/src/db/project-detector.ts
+++ b/src/db/project-detector.ts
@@ -30,7 +30,21 @@ export function detectProject(cwd: string): DetectedProject | null {
 }
 
 function readOriginRemote(projectRoot: string): string | null {
-  const cfgPath = path.join(projectRoot, ".git", "config");
+  const dotGit = path.join(projectRoot, ".git");
+  let cfgPath = path.join(dotGit, "config");
+  try {
+    if (fs.statSync(dotGit).isFile()) {
+      const pointer = fs.readFileSync(dotGit, "utf8").trim();
+      const match = /^gitdir:\s*(.+)$/i.exec(pointer);
+      const gitDirRef = match?.[1];
+      if (!gitDirRef) return null;
+      const gitDir = path.resolve(projectRoot, gitDirRef);
+      cfgPath = path.resolve(gitDir, "..", "..", "config");
+    }
+  } catch {
+    return null;
+  }
+
   let text: string;
   try {
     text = fs.readFileSync(cfgPath, "utf8");

--- a/src/db/projects.ts
+++ b/src/db/projects.ts
@@ -1,4 +1,6 @@
 import type Database from "better-sqlite3";
+import { existsSync, realpathSync } from "node:fs";
+import path from "node:path";
 
 export interface Project {
   slug: string;
@@ -109,12 +111,14 @@ export function findProjectByRepo(db: Database.Database, remote: string): Projec
  * markerless multi-repo container directory resolve to its project slug.
  */
 export function findProjectByPath(db: Database.Database, dir: string): Project | null {
+  const target = existsSync(dir) ? realpathSync.native(dir) : path.resolve(dir);
   let best: Project | null = null;
   let bestLen = -1;
   for (const p of listProjects(db)) {
-    for (const mp of p.memberPaths) {
-      if (mp.length > bestLen && (dir === mp || dir.startsWith(mp + "/"))) {
-        bestLen = mp.length;
+    for (const memberPath of p.memberPaths) {
+      const candidate = existsSync(memberPath) ? realpathSync.native(memberPath) : path.resolve(memberPath);
+      if (candidate.length > bestLen && (target === candidate || target.startsWith(candidate + path.sep))) {
+        bestLen = candidate.length;
         best = p;
       }
     }

--- a/src/db/resolve-project.ts
+++ b/src/db/resolve-project.ts
@@ -25,7 +25,9 @@ function canonicalPath(input: string): string {
   return existsSync(input) ? realpathSync.native(input) : path.resolve(input);
 }
 
-function resolvePath(db: Database.Database, input: string): Extract<ProjectScopeResolution, { kind: "resolved" }> | null {
+type PathResolution = Extract<ProjectScopeResolution, { kind: "resolved" }> | { kind: "slug_collision" };
+
+function resolvePath(db: Database.Database, input: string): PathResolution | null {
   const cwd = canonicalPath(input);
   const byPath = findProjectByPath(db, cwd);
   if (byPath) {
@@ -42,18 +44,22 @@ function resolvePath(db: Database.Database, input: string): Extract<ProjectScope
     if (byRepo) {
       return { kind: "resolved", slug: byRepo.slug, source: "git_remote" };
     }
+    const slug = slugify(path.basename(normalizedRemote));
+    if (getProjectBySlug(db, slug)) return { kind: "slug_collision" };
     return {
       kind: "resolved",
-      slug: slugify(path.basename(normalizedRemote)),
+      slug,
       source: "derived",
       memberPaths: [projectRoot],
       memberRepos: [normalizedRemote],
     };
   }
 
+  const slug = slugify(path.basename(projectRoot));
+  if (getProjectBySlug(db, slug)) return { kind: "slug_collision" };
   return {
     kind: "resolved",
-    slug: slugify(path.basename(projectRoot)),
+    slug,
     source: "derived",
     memberPaths: [projectRoot],
     memberRepos: [],
@@ -73,10 +79,16 @@ export function resolveProjectScope(
     return { kind: "resolved", slug: explicit, source: "explicit" };
   }
 
-  const resolutions = paths.flatMap((candidate) => {
+  const pathResolutions = paths.flatMap((candidate) => {
     const resolved = resolvePath(db, candidate);
     return resolved ? [resolved] : [];
   });
+  if (pathResolutions.some((result) => result.kind === "slug_collision")) {
+    return { kind: "unresolved" };
+  }
+  const resolutions = pathResolutions.filter(
+    (result): result is Extract<ProjectScopeResolution, { kind: "resolved" }> => result.kind === "resolved",
+  );
   if (resolutions.length === 0) return { kind: "unresolved" };
 
   const slugs = [...new Set(resolutions.map((result) => result.slug))].sort();

--- a/src/db/resolve-project.ts
+++ b/src/db/resolve-project.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { existsSync, realpathSync } from "node:fs";
 import path from "node:path";
 import { detectProject } from "./project-detector.js";
 import { findProjectByRepo, findProjectByPath, getProjectBySlug, upsertProject, normalizeGitRemote } from "./projects.js";
@@ -8,77 +9,115 @@ export function slugify(name: string): string {
   return name.trim().toLowerCase().replace(/[\s_]+/g, "-").replace(/[^a-z0-9-]/g, "").replace(/-+/g, "-").replace(/^-|-$/g, "") || "project";
 }
 
-/**
- * Shared detection logic: walk up from cwd to find the project root and
- * remote, then derive a slug — without any database writes.
- *
- * Returns the slug and the detected info, or null if no project marker is found.
- */
-function detectSlug(db: Database.Database, cwd: string): { slug: string; remote: string | null; projectRoot: string } | null {
-  // Registry path match first — handles markerless multi-repo containers and is
-  // setup-portable: the caller's real dir maps to a human-curated slug directly.
+export type ProjectScopeResolution =
+  | {
+      kind: "resolved";
+      slug: string;
+      source: "explicit" | "member_path" | "git_remote" | "derived";
+      memberPaths?: string[];
+      memberRepos?: string[];
+    }
+  | { kind: "unresolved" }
+  | { kind: "ambiguous"; slugs: string[] }
+  | { kind: "invalid_explicit"; slug: string };
+
+function canonicalPath(input: string): string {
+  return existsSync(input) ? realpathSync.native(input) : path.resolve(input);
+}
+
+function resolvePath(db: Database.Database, input: string): Extract<ProjectScopeResolution, { kind: "resolved" }> | null {
+  const cwd = canonicalPath(input);
   const byPath = findProjectByPath(db, cwd);
-  if (byPath) return { slug: byPath.slug, remote: null, projectRoot: cwd };
+  if (byPath) {
+    return { kind: "resolved", slug: byPath.slug, source: "member_path" };
+  }
 
   const detected = detectProject(cwd);
   if (!detected) return null;
+  const projectRoot = canonicalPath(detected.projectRoot);
 
   if (detected.remote) {
-    // Registry match takes priority (returns the human-confirmed slug).
-    const existing = findProjectByRepo(db, detected.remote);
-    if (existing) {
-      return { slug: existing.slug, remote: detected.remote, projectRoot: detected.projectRoot };
+    const normalizedRemote = normalizeGitRemote(detected.remote);
+    const byRepo = findProjectByRepo(db, normalizedRemote);
+    if (byRepo) {
+      return { kind: "resolved", slug: byRepo.slug, source: "git_remote" };
     }
-    const normalized = normalizeGitRemote(detected.remote);
-    return { slug: slugify(path.basename(normalized)), remote: detected.remote, projectRoot: detected.projectRoot };
+    return {
+      kind: "resolved",
+      slug: slugify(path.basename(normalizedRemote)),
+      source: "derived",
+      memberPaths: [projectRoot],
+      memberRepos: [normalizedRemote],
+    };
   }
 
-  // No remote — derive slug from directory basename.
-  return { slug: slugify(path.basename(detected.projectRoot)), remote: null, projectRoot: detected.projectRoot };
+  return {
+    kind: "resolved",
+    slug: slugify(path.basename(projectRoot)),
+    source: "derived",
+    memberPaths: [projectRoot],
+    memberRepos: [],
+  };
 }
 
-/**
- * Resolve the project slug for a working directory. Matches the registry by git
- * remote; if a real project root is detected (detectProject non-null):
- *   - has a remote  → registry match or provision from remote basename
- *   - no remote     → provision from the project-root basename
- *
- * Returns null when detectProject finds no project marker (e.g. the server's
- * home/install dir). Callers should treat null as "unresolved" and not stamp a
- * provisional project.
- *
- * Note: for HTTP transport / clients that launch the server outside the project
- * dir, cwd-resolution is best-effort; callers should pass an explicit
- * project_identifier (the macOS app does this from its active-project context).
- */
+/** Resolve explicit or multi-root scope without mutating the project registry. */
+export function resolveProjectScope(
+  db: Database.Database,
+  paths: string[],
+  explicit?: string,
+): ProjectScopeResolution {
+  if (explicit !== undefined) {
+    if (slugify(explicit) !== explicit || !getProjectBySlug(db, explicit)) {
+      return { kind: "invalid_explicit", slug: explicit };
+    }
+    return { kind: "resolved", slug: explicit, source: "explicit" };
+  }
+
+  const resolutions = paths.flatMap((candidate) => {
+    const resolved = resolvePath(db, candidate);
+    return resolved ? [resolved] : [];
+  });
+  if (resolutions.length === 0) return { kind: "unresolved" };
+
+  const slugs = [...new Set(resolutions.map((result) => result.slug))].sort();
+  if (slugs.length > 1) return { kind: "ambiguous", slugs };
+
+  const priority = { member_path: 0, git_remote: 1, derived: 2, explicit: 3 } as const;
+  const best = resolutions.sort((a, b) => priority[a.source] - priority[b.source])[0]!;
+  if (best.source !== "derived") return best;
+
+  return {
+    ...best,
+    memberPaths: [...new Set(resolutions.flatMap((result) => result.memberPaths ?? []))],
+    memberRepos: [...new Set(resolutions.flatMap((result) => result.memberRepos ?? []))],
+  };
+}
+
+/** Persist a detected derived scope before a personal capture. */
+export function upsertProvisionalProject(
+  db: Database.Database,
+  resolution: Extract<ProjectScopeResolution, { kind: "resolved" }>,
+): void {
+  if (resolution.source !== "derived" || getProjectBySlug(db, resolution.slug)) return;
+  upsertProject(db, {
+    slug: resolution.slug,
+    displayName: resolution.slug,
+    memberRepos: resolution.memberRepos ?? [],
+    memberPaths: resolution.memberPaths ?? [],
+    provisional: true,
+  });
+}
+
+/** Backward-compatible single-directory write resolution. */
 export function resolveProjectIdentifier(db: Database.Database, cwd: string): string | null {
-  const info = detectSlug(db, cwd);
-  if (!info) return null;
-
-  const { slug, remote, projectRoot } = info;
-
-  // Only provision if no existing entry for this slug.
-  const normalized = remote ? normalizeGitRemote(remote) : null;
-  upsertProvisional(db, slug, normalized ? [normalized] : [], [projectRoot]);
-  return slug;
+  const result = resolveProjectScope(db, [cwd]);
+  if (result.kind !== "resolved") return null;
+  upsertProvisionalProject(db, result);
+  return result.slug;
 }
 
-/**
- * Read-only variant of resolveProjectIdentifier: derives the current project
- * slug from cwd WITHOUT writing anything to the database.
- *
- * - Registry hit (remote matches a registered project) → returns that project's slug.
- * - Detected project with unmatched remote → returns slugified remote basename.
- * - Detected project with no remote → returns slugified directory basename.
- * - No project marker found → returns null.
- */
+/** Backward-compatible single-directory read resolution. */
 export function currentProjectSlug(db: Database.Database, cwd: string): string | null {
-  const info = detectSlug(db, cwd);
-  return info ? info.slug : null;
-}
-
-function upsertProvisional(db: Database.Database, slug: string, repos: string[], paths: string[]): void {
-  const existing = getProjectBySlug(db, slug);
-  if (existing) return; // don't clobber an existing (possibly human-confirmed) project
-  upsertProject(db, { slug, displayName: slug, memberRepos: repos, memberPaths: paths, provisional: true });
+  const result = resolveProjectScope(db, [cwd]);
+  return result.kind === "resolved" ? result.slug : null;
 }

--- a/src/mcp/resolve-dir.ts
+++ b/src/mcp/resolve-dir.ts
@@ -1,13 +1,48 @@
+import { existsSync, realpathSync } from "node:fs";
+import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 export interface RootRef { uri: string }
 
-/** Choose the directory to resolve the project from: first file:// root, else fallback cwd. */
-export function pickResolutionDir(roots: RootRef[] | undefined, fallbackCwd: string): string {
-  for (const r of roots ?? []) {
-    if (r.uri.startsWith("file://")) {
-      try { return fileURLToPath(r.uri); } catch { /* ignore malformed */ }
+export type ResolutionRootResult =
+  | { kind: "resolved"; paths: string[] }
+  | { kind: "unresolved" }
+  | { kind: "ambiguous"; paths: string[] };
+
+/** Decode, standardize and deduplicate every file:// root advertised by a client. */
+export function normalizeFileRoots(roots: RootRef[] | undefined): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+
+  for (const root of roots ?? []) {
+    let decoded: string;
+    try {
+      const url = new URL(root.uri);
+      if (url.protocol !== "file:") continue;
+      decoded = fileURLToPath(url);
+    } catch {
+      continue;
+    }
+
+    const standardized = existsSync(decoded)
+      ? realpathSync.native(decoded)
+      : path.resolve(decoded);
+    const normalized = standardized === path.parse(standardized).root
+      ? standardized
+      : standardized.replace(/[\\/]+$/, "");
+    if (!seen.has(normalized)) {
+      seen.add(normalized);
+      paths.push(normalized);
     }
   }
-  return fallbackCwd;
+
+  return paths;
+}
+
+/** Use cwd only for no-roots clients, and never treat production / as a project. */
+export function fallbackResolutionRoots(cwd: string): ResolutionRootResult {
+  if (!path.isAbsolute(cwd) || cwd === path.parse(cwd).root || !existsSync(cwd)) {
+    return { kind: "unresolved" };
+  }
+  return { kind: "resolved", paths: [realpathSync.native(cwd)] };
 }

--- a/src/mcp/resolve-dir.ts
+++ b/src/mcp/resolve-dir.ts
@@ -1,4 +1,4 @@
-import { existsSync, realpathSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -41,7 +41,7 @@ export function normalizeFileRoots(roots: RootRef[] | undefined): string[] {
 
 /** Use cwd only for no-roots clients, and never treat production / as a project. */
 export function fallbackResolutionRoots(cwd: string): ResolutionRootResult {
-  if (!path.isAbsolute(cwd) || cwd === path.parse(cwd).root || !existsSync(cwd)) {
+  if (!path.isAbsolute(cwd) || cwd === path.parse(cwd).root || !existsSync(cwd) || !statSync(cwd).isDirectory()) {
     return { kind: "unresolved" };
   }
   return { kind: "resolved", paths: [realpathSync.native(cwd)] };

--- a/src/mcp/scope-defaults.ts
+++ b/src/mcp/scope-defaults.ts
@@ -1,9 +1,6 @@
 import type Database from "better-sqlite3";
-import { currentProjectSlug } from "../db/resolve-project.js";
+import { resolveProjectScope } from "../db/resolve-project.js";
 
-/**
- * Read-tool args that can carry project scoping fields.
- */
 export interface ScopableArgs {
   project_identifier?: string;
   include_shared?: boolean;
@@ -11,39 +8,36 @@ export interface ScopableArgs {
   [key: string]: unknown;
 }
 
-/**
- * Apply cwd-based default project scoping to read-tool args when the caller
- * has NOT explicitly provided a project_identifier and has NOT opted out via
- * all_projects: true.
- *
- * Rules:
- *  - If all_projects === true  → return args unchanged (caller wants global view).
- *  - If project_identifier is already set → return args unchanged (explicit wins).
- *  - Otherwise → resolve current slug from cwd; if non-null, inject
- *    project_identifier = slug and default include_shared = true.
- *
- * This is extracted as a pure(-ish) function so it can be unit-tested
- * independently of the MCP server registration machinery.
- */
+export type AppliedScope =
+  | { kind: "applied"; args: ScopableArgs }
+  | { kind: "error"; category: "project_scope_invalid"; message: string };
+
+/** Apply exact project scope, failing closed to shared-only when roots are unresolved. */
 export function applyDefaultScope(
   args: ScopableArgs,
   db: Database.Database,
-  cwd: string,
-): ScopableArgs {
-  // Caller opted out of auto-scoping.
-  if (args.all_projects === true) return args;
+  paths: string[],
+): AppliedScope {
+  if (args.all_projects === true) return { kind: "applied", args };
 
-  // Caller already provided an explicit project scope.
-  if (args.project_identifier !== undefined) return args;
-
-  // Attempt to derive the current project slug from cwd.
-  const slug = currentProjectSlug(db, cwd);
-  // No slug resolved → fail safe to shared-only (never expose every project).
-  if (!slug) return { ...args, shared_only: true };
+  const resolution = resolveProjectScope(db, paths, args.project_identifier);
+  if (resolution.kind === "invalid_explicit") {
+    return {
+      kind: "error",
+      category: "project_scope_invalid",
+      message: `project_identifier "${resolution.slug}" is unknown or noncanonical. Pass a registered canonical project_identifier or configure project roots.`,
+    };
+  }
+  if (resolution.kind !== "resolved") {
+    return { kind: "applied", args: { ...args, project_identifier: undefined, shared_only: true } };
+  }
 
   return {
-    ...args,
-    project_identifier: slug,
-    include_shared: args.include_shared ?? true,
+    kind: "applied",
+    args: {
+      ...args,
+      project_identifier: resolution.slug,
+      include_shared: args.include_shared ?? true,
+    },
   };
 }

--- a/src/mcp/scope-defaults.ts
+++ b/src/mcp/scope-defaults.ts
@@ -18,8 +18,6 @@ export function applyDefaultScope(
   db: Database.Database,
   paths: string[],
 ): AppliedScope {
-  if (args.all_projects === true) return { kind: "applied", args };
-
   const resolution = resolveProjectScope(db, paths, args.project_identifier);
   if (resolution.kind === "invalid_explicit") {
     return {
@@ -28,6 +26,7 @@ export function applyDefaultScope(
       message: `project_identifier "${resolution.slug}" is unknown or noncanonical. Pass a registered canonical project_identifier or configure project roots.`,
     };
   }
+  if (args.all_projects === true) return { kind: "applied", args };
   if (resolution.kind !== "resolved") {
     return { kind: "applied", args: { ...args, project_identifier: undefined, shared_only: true } };
   }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -17,8 +17,9 @@ import { handleGetBrief } from "../tools/brief.js";
 import { handleSelectContext } from "../tools/context.js";
 import type { ToolResult } from "../tools/helpers.js";
 import { applyDefaultScope } from "./scope-defaults.js";
-import { pickResolutionDir } from "./resolve-dir.js";
-import type { RootRef } from "./resolve-dir.js";
+import { fallbackResolutionRoots, normalizeFileRoots } from "./resolve-dir.js";
+import type { ResolutionRootResult } from "./resolve-dir.js";
+import { resolveProjectScope } from "../db/resolve-project.js";
 import { ensureSeedProjects } from "../db/seed.js";
 import { loadProjectSeed, toProjects } from "../integrity/project-seed.js";
 import {
@@ -29,6 +30,7 @@ import {
   MAX_PEOPLE_COUNT,
   MAX_PERSON_LENGTH,
   MAX_BULK_THOUGHTS,
+  toolError,
 } from "../tools/helpers.js";
 import { getEmbeddingConfig, generateEmbedding, getEmbeddingProviderId } from "../db/embedding.js";
 import { storeEmbedding } from "../db/vectors.js";
@@ -56,41 +58,31 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
   // match known paths. Empty on a fresh install — nothing bundled.
   ensureSeedProjects(db.db, toProjects(loadProjectSeed()));
 
-  // ---------------------------------------------------------------------------
-  // Client roots — used to resolve the caller's working directory.
-  // The server runs at process.cwd() = "/" in production (launched by macOS app),
-  // so we prefer the first file:// root advertised by the MCP client instead.
-  // ---------------------------------------------------------------------------
-  let clientRoots: RootRef[] | undefined;
-  let rootsFetched = false;
+  // Await and memoize the first client roots request so the first scoped call
+  // cannot race ahead with the server's launch directory.
+  let rootsPromise: Promise<ResolutionRootResult> | undefined;
 
-  async function refreshRoots(): Promise<void> {
+  async function fetchResolutionRoots(): Promise<ResolutionRootResult> {
     try {
-      const res = await server.server.listRoots();
-      clientRoots = res.roots as RootRef[];
+      const response = await server.server.listRoots();
+      const paths = normalizeFileRoots(response.roots);
+      return paths.length > 0 ? { kind: "resolved", paths } : { kind: "unresolved" };
     } catch {
-      // Client does not support roots — leave clientRoots undefined.
+      return fallbackResolutionRoots(process.cwd());
     }
-    rootsFetched = true;
   }
 
-  // Re-fetch when the client signals its roots have changed.
+  function resolutionRoots(): Promise<ResolutionRootResult> {
+    rootsPromise ??= fetchResolutionRoots();
+    return rootsPromise;
+  }
+
   server.server.setNotificationHandler(RootsListChangedNotificationSchema, () => {
-    void refreshRoots();
+    rootsPromise = undefined;
   });
 
-  /** Lazily trigger the first roots fetch (no-op after the first call). */
-  function ensureRoots(): void {
-    if (!rootsFetched) {
-      rootsFetched = true; // set eagerly to prevent concurrent fetches
-      void refreshRoots();
-    }
-  }
-
-  /** The directory to use for project resolution in the current handler call. */
-  function resolutionDir(): string {
-    ensureRoots();
-    return pickResolutionDir(clientRoots, process.cwd());
+  function pathsFrom(result: ResolutionRootResult): string[] {
+    return result.kind === "unresolved" ? [] : result.paths;
   }
 
   // Initialize embedding config from environment
@@ -202,7 +194,9 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       },
     },
     withLogging("capture_thought", async (args) => {
-      const result = handleCaptureThought(db, args as Record<string, unknown>, resolutionDir());
+      const roots = await resolutionRoots();
+      const scope = resolveProjectScope(db.db, pathsFrom(roots));
+      const result = handleCaptureThought(db, args as Record<string, unknown>, scope);
       // Auto-embed after capture when a server-side embedding provider is configured
       if (!result.isError && embeddingConfig.provider !== "none") {
         try {
@@ -276,9 +270,11 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
         graph_depth: z.number().describe("Graph traversal depth after retrieval (0 = none, max 5). When >= 1, related thoughts reachable via graph edges are included in graph_related.").optional(),
       },
     },
-    withLogging("search_thoughts", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
-      return handleSearchThoughts(db, scoped as Record<string, unknown>);
+    withLogging("search_thoughts", async (args) => {
+      const roots = await resolutionRoots();
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, pathsFrom(roots));
+      if (scoped.kind === "error") return toolError(scoped.category, scoped.message);
+      return handleSearchThoughts(db, scoped.args as Record<string, unknown>);
     }),
   );
 
@@ -314,9 +310,11 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
         offset: z.number().describe("Pagination offset").optional(),
       },
     },
-    withLogging("list_thoughts", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
-      return handleListThoughts(db, scoped as Record<string, unknown>);
+    withLogging("list_thoughts", async (args) => {
+      const roots = await resolutionRoots();
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, pathsFrom(roots));
+      if (scoped.kind === "error") return toolError(scoped.category, scoped.message);
+      return handleListThoughts(db, scoped.args as Record<string, unknown>);
     }),
   );
 
@@ -499,9 +497,11 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
           .optional(),
       },
     },
-    withLogging("get_brief", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
-      return handleGetBrief(db, scoped as Record<string, unknown>);
+    withLogging("get_brief", async (args) => {
+      const roots = await resolutionRoots();
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, pathsFrom(roots));
+      if (scoped.kind === "error") return toolError(scoped.category, scoped.message);
+      return handleGetBrief(db, scoped.args as Record<string, unknown>);
     }),
   );
 
@@ -531,9 +531,11 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
         limit: z.number().describe("Max thoughts to return (default: 20, max: 100)").optional(),
       },
     },
-    withLogging("select_context", (args) => {
-      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, resolutionDir());
-      return handleSelectContext(db, scoped as Record<string, unknown>);
+    withLogging("select_context", async (args) => {
+      const roots = await resolutionRoots();
+      const scoped = applyDefaultScope(args as Record<string, unknown>, db.db, pathsFrom(roots));
+      if (scoped.kind === "error") return toolError(scoped.category, scoped.message);
+      return handleSelectContext(db, scoped.args as Record<string, unknown>);
     }),
   );
 

--- a/src/tools/capture.ts
+++ b/src/tools/capture.ts
@@ -205,7 +205,7 @@ function captureScope(
   db: ThoughtDatabase,
   args: { project_identifier?: string; visibility?: string; type?: string },
   detectedScope: ProjectScopeResolution,
-): { slug: string | null } | ToolResult {
+): { slug: string | null; resolution?: Extract<ProjectScopeResolution, { kind: "resolved" }> } | ToolResult {
   const resolution = args.project_identifier
     ? resolveProjectScope(db.db, [], args.project_identifier)
     : detectedScope;
@@ -222,11 +222,12 @@ function captureScope(
     return toolError("project_scope_ambiguous", `Client roots resolve to multiple projects (${resolution.slugs.join(", ")}). Pass a registered project_identifier.`);
   }
 
-  upsertProvisionalProject(db.db, resolution);
-  return { slug: resolution.slug };
+  return { slug: resolution.slug, resolution };
 }
 
-function isToolError(value: { slug: string | null } | ToolResult): value is ToolResult {
+function isToolError(
+  value: { slug: string | null; resolution?: Extract<ProjectScopeResolution, { kind: "resolved" }> } | ToolResult,
+): value is ToolResult {
   return "content" in value;
 }
 
@@ -262,9 +263,14 @@ export function handleCaptureThought(
     const scopeError = scopes.find(isToolError);
     if (scopeError) return scopeError;
 
-    const results = a.thoughts.map((thought, index) =>
-      captureSingle(db, thought, (scopes[index] as { slug: string | null }).slug),
-    );
+    const results = db.db.transaction(() => a.thoughts!.map((thought, index) => {
+      const scope = scopes[index] as {
+        slug: string | null;
+        resolution?: Extract<ProjectScopeResolution, { kind: "resolved" }>;
+      };
+      if (scope.resolution) upsertProvisionalProject(db.db, scope.resolution);
+      return captureSingle(db, thought, scope.slug);
+    }))();
 
     return toolSuccess({
       captured: results.length,
@@ -292,22 +298,26 @@ export function handleCaptureThought(
 
   const scope = captureScope(db, a, detectedScope);
   if (isToolError(scope)) return scope;
+  const content = a.content;
 
-  const result = captureSingle(db, {
-    content: a.content,
-    summary: a.summary,
-    type: a.type,
-    source: a.source,
-    source_agent: a.source_agent,
-    trust_level: a.trust_level,
-    project: a.project,
-    project_identifier: a.project_identifier,
-    visibility: a.visibility,
-    topics: a.topics,
-    people: a.people,
-    metadata: a.metadata,
-    related_to: a.related_to,
-  }, scope.slug);
+  const result = db.db.transaction(() => {
+    if (scope.resolution) upsertProvisionalProject(db.db, scope.resolution);
+    return captureSingle(db, {
+      content,
+      summary: a.summary,
+      type: a.type,
+      source: a.source,
+      source_agent: a.source_agent,
+      trust_level: a.trust_level,
+      project: a.project,
+      project_identifier: a.project_identifier,
+      visibility: a.visibility,
+      topics: a.topics,
+      people: a.people,
+      metadata: a.metadata,
+      related_to: a.related_to,
+    }, scope.slug);
+  })();
 
   const suggested_connections = findSuggestedConnections(
     db,

--- a/src/tools/capture.ts
+++ b/src/tools/capture.ts
@@ -2,7 +2,8 @@ import type { ThoughtDatabase } from "../db/database.js";
 import { insertThought, getThought } from "../db/thoughts.js";
 import { linkThoughts } from "../db/edges.js";
 import { searchThoughts, sanitizeFTSQuery } from "../db/fts.js";
-import { resolveProjectIdentifier } from "../db/resolve-project.js";
+import { resolveProjectScope, upsertProvisionalProject } from "../db/resolve-project.js";
+import type { ProjectScopeResolution } from "../db/resolve-project.js";
 import {
   toolSuccess,
   toolError,
@@ -200,10 +201,39 @@ function captureSingle(
   return { id, linked, skipped };
 }
 
+function captureScope(
+  db: ThoughtDatabase,
+  args: { project_identifier?: string; visibility?: string; type?: string },
+  detectedScope: ProjectScopeResolution,
+): { slug: string | null } | ToolResult {
+  const resolution = args.project_identifier
+    ? resolveProjectScope(db.db, [], args.project_identifier)
+    : detectedScope;
+  if (resolution.kind === "invalid_explicit") {
+    return toolError("project_scope_invalid", `project_identifier "${resolution.slug}" is unknown or noncanonical. Pass a registered canonical project_identifier.`);
+  }
+
+  const visibility = args.visibility ?? (args.type === "preference" ? "shared" : "personal");
+  if (visibility === "shared" && !args.project_identifier) return { slug: null };
+  if (resolution.kind === "unresolved") {
+    return toolError("project_scope_unresolved", "Personal captures require a project. Pass a registered project_identifier or configure MCP client roots.");
+  }
+  if (resolution.kind === "ambiguous") {
+    return toolError("project_scope_ambiguous", `Client roots resolve to multiple projects (${resolution.slugs.join(", ")}). Pass a registered project_identifier.`);
+  }
+
+  upsertProvisionalProject(db.db, resolution);
+  return { slug: resolution.slug };
+}
+
+function isToolError(value: { slug: string | null } | ToolResult): value is ToolResult {
+  return "content" in value;
+}
+
 export function handleCaptureThought(
   db: ThoughtDatabase,
   args: Record<string, unknown>,
-  cwd: string = process.cwd(),
+  detectedScope: ProjectScopeResolution = resolveProjectScope(db.db, [process.cwd()]),
 ): ToolResult {
   const a = args as unknown as CaptureArgs;
 
@@ -220,27 +250,21 @@ export function handleCaptureThought(
       );
     }
 
-    // Only resolve from cwd when at least one thought lacks an explicit project_identifier.
-    // This avoids the filesystem walk + registry write when every thought already specifies it.
-    const needsResolution = a.thoughts.some((t) => !t.project_identifier);
-    const resolvedSlug: string | null = needsResolution
-      ? resolveProjectIdentifier(db.db, cwd)
-      : null;
-
-    const results: Array<{ id: string; linked: string[]; skipped: string[] }> = [];
     for (const thought of a.thoughts) {
       if (!thought.content || typeof thought.content !== "string") {
-        return toolError(
-          "invalid_input",
-          "Each thought in bulk capture must have a content string",
-        );
+        return toolError("invalid_input", "Each thought in bulk capture must have a content string");
       }
       const err = validateThoughtInput(thought);
-      if (err) {
-        return toolError("invalid_input", err);
-      }
-      results.push(captureSingle(db, thought, resolvedSlug));
+      if (err) return toolError("invalid_input", err);
     }
+
+    const scopes = a.thoughts.map((thought) => captureScope(db, thought, detectedScope));
+    const scopeError = scopes.find(isToolError);
+    if (scopeError) return scopeError;
+
+    const results = a.thoughts.map((thought, index) =>
+      captureSingle(db, thought, (scopes[index] as { slug: string | null }).slug),
+    );
 
     return toolSuccess({
       captured: results.length,
@@ -266,11 +290,8 @@ export function handleCaptureThought(
     return toolError("invalid_input", singleErr);
   }
 
-  // Only resolve from cwd when the explicit project_identifier is absent.
-  // This avoids the filesystem walk + registry write when the caller already specifies it.
-  const resolvedSlug: string | null = a.project_identifier
-    ? null
-    : resolveProjectIdentifier(db.db, cwd);
+  const scope = captureScope(db, a, detectedScope);
+  if (isToolError(scope)) return scope;
 
   const result = captureSingle(db, {
     content: a.content,
@@ -286,7 +307,7 @@ export function handleCaptureThought(
     people: a.people,
     metadata: a.metadata,
     related_to: a.related_to,
-  }, resolvedSlug);
+  }, scope.slug);
 
   const suggested_connections = findSuggestedConnections(
     db,

--- a/tests/db/project-scope-fixture.test.ts
+++ b/tests/db/project-scope-fixture.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import Database from "better-sqlite3";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { runMigrations } from "../../src/db/migrations.js";
+import { upsertProject } from "../../src/db/projects.js";
+import { resolveProjectScope } from "../../src/db/resolve-project.js";
+
+type Fixture = {
+  cases: Array<{
+    name: string;
+    projects: Array<{ slug: string; member_paths: string[]; member_repos: string[] }>;
+    roots: string[];
+    explicit?: string;
+    expected: Record<string, unknown>;
+  }>;
+};
+
+const fixturePath = fileURLToPath(new URL("../fixtures/project-scope-resolution.json", import.meta.url));
+function loadFixture(): Fixture {
+  try {
+    return JSON.parse(readFileSync(fixturePath, "utf8")) as Fixture;
+  } catch (error) {
+    throw new Error(`Invalid project-scope fixture: ${String(error)}`, { cause: error });
+  }
+}
+const fixture = loadFixture();
+
+describe("project scope conformance fixture", () => {
+  for (const testCase of fixture.cases) {
+    it(testCase.name, () => {
+      const db = new Database(":memory:");
+      runMigrations(db);
+      for (const project of testCase.projects) {
+        upsertProject(db, {
+          slug: project.slug,
+          displayName: project.slug,
+          memberPaths: project.member_paths,
+          memberRepos: project.member_repos,
+          provisional: false,
+        });
+      }
+      expect(resolveProjectScope(db, testCase.roots, testCase.explicit)).toMatchObject(testCase.expected);
+      db.close();
+    });
+  }
+});

--- a/tests/db/resolve-project.test.ts
+++ b/tests/db/resolve-project.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { runMigrations } from "../../src/db/migrations.js";
 import { upsertProject, getProjectBySlug, listProjects } from "../../src/db/projects.js";
-import { resolveProjectIdentifier, currentProjectSlug } from "../../src/db/resolve-project.js";
+import { resolveProjectIdentifier, currentProjectSlug, resolveProjectScope, slugify } from "../../src/db/resolve-project.js";
 
 let db: Database.Database;
 beforeEach(() => { db = new Database(":memory:"); runMigrations(db); });
@@ -16,6 +16,71 @@ function repo(remote: string): string {
   writeFileSync(join(root, ".git", "config"), `[remote "origin"]\n\turl = ${remote}\n`);
   return root;
 }
+
+describe("resolveProjectScope", () => {
+  it("keeps slugify byte-identical to ADR 0001", () => {
+    expect(slugify("  My_Project -- Name!  ")).toBe("my-project-name");
+    expect(slugify("___")).toBe("project");
+  });
+
+  it("accepts only registered canonical explicit slugs and gives them precedence", () => {
+    const root = repo("https://github.com/acme/other.git");
+    upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: [], provisional: false });
+
+    expect(resolveProjectScope(db, [root], "shelby")).toEqual({
+      kind: "resolved", slug: "shelby", source: "explicit",
+    });
+    expect(resolveProjectScope(db, [root], "Shelby")).toEqual({
+      kind: "invalid_explicit", slug: "Shelby",
+    });
+    expect(resolveProjectScope(db, [root], "missing")).toEqual({
+      kind: "invalid_explicit", slug: "missing",
+    });
+  });
+
+  it("uses the registry's longest member-path match", () => {
+    const container = mkdtempSync(join(tmpdir(), "rp-container-"));
+    const nested = join(container, "nested", "repo");
+    mkdirSync(nested, { recursive: true });
+    upsertProject(db, { slug: "outer", displayName: "Outer", memberRepos: [], memberPaths: [container], provisional: false });
+    upsertProject(db, { slug: "inner", displayName: "Inner", memberRepos: [], memberPaths: [join(container, "nested")], provisional: false });
+
+    expect(resolveProjectScope(db, [nested])).toMatchObject({ kind: "resolved", slug: "inner", source: "member_path" });
+  });
+
+  it("matches normalized HTTPS and SCP-style remotes", () => {
+    upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: ["github.com/Studio-Moser/Shelby-MCP"], memberPaths: [], provisional: false });
+    const https = repo("https://github.com/Studio-Moser/Shelby-MCP.git");
+    const scp = repo("git@github.com:Studio-Moser/Shelby-MCP.git");
+
+    expect(resolveProjectScope(db, [https])).toMatchObject({ kind: "resolved", slug: "shelby", source: "git_remote" });
+    expect(resolveProjectScope(db, [scp])).toMatchObject({ kind: "resolved", slug: "shelby", source: "git_remote" });
+  });
+
+  it("combines same-slug roots and reports different-slug roots as ambiguous", () => {
+    const one = repo("https://github.com/acme/one.git");
+    const oneAgain = repo("git@github.com:acme/one.git");
+    const two = repo("https://github.com/acme/two.git");
+
+    expect(resolveProjectScope(db, [one, oneAgain])).toMatchObject({ kind: "resolved", slug: "one", source: "derived" });
+    expect(resolveProjectScope(db, [one, two])).toEqual({ kind: "ambiguous", slugs: ["one", "two"] });
+  });
+
+  it("leaves markerless unregistered containers unresolved", () => {
+    const dir = mkdtempSync(join(tmpdir(), "rp-plain-"));
+    expect(resolveProjectScope(db, [dir])).toEqual({ kind: "unresolved" });
+  });
+
+  it("resolves a git worktree from the common repository config", () => {
+    const common = mkdtempSync(join(tmpdir(), "rp-common-"));
+    mkdirSync(join(common, ".git", "worktrees", "feature"), { recursive: true });
+    writeFileSync(join(common, ".git", "config"), '[remote "origin"]\n\turl = git@github.com:acme/worktree.git\n');
+    const worktree = mkdtempSync(join(tmpdir(), "rp-worktree-"));
+    writeFileSync(join(worktree, ".git"), `gitdir: ${join(common, ".git", "worktrees", "feature")}\n`);
+
+    expect(resolveProjectScope(db, [worktree])).toMatchObject({ kind: "resolved", slug: "worktree", source: "derived" });
+  });
+});
 
 describe("resolveProjectIdentifier", () => {
   it("returns the slug of a registered project matching the repo remote", () => {

--- a/tests/db/resolve-project.test.ts
+++ b/tests/db/resolve-project.test.ts
@@ -66,6 +66,19 @@ describe("resolveProjectScope", () => {
     expect(resolveProjectScope(db, [one, two])).toEqual({ kind: "ambiguous", slugs: ["one", "two"] });
   });
 
+  it("fails closed when an unmatched remote derives an occupied slug", () => {
+    upsertProject(db, {
+      slug: "shared-name",
+      displayName: "Original",
+      memberRepos: ["github.com/owner/shared-name"],
+      memberPaths: [],
+      provisional: false,
+    });
+    const unrelated = repo("https://gitlab.com/other/shared-name.git");
+
+    expect(resolveProjectScope(db, [unrelated])).toEqual({ kind: "unresolved" });
+  });
+
   it("leaves markerless unregistered containers unresolved", () => {
     const dir = mkdtempSync(join(tmpdir(), "rp-plain-"));
     expect(resolveProjectScope(db, [dir])).toEqual({ kind: "unresolved" });

--- a/tests/fixtures/project-scope-resolution.json
+++ b/tests/fixtures/project-scope-resolution.json
@@ -1,0 +1,44 @@
+{
+  "version": 1,
+  "description": "Shared HMC project-scope cases. Swift parity must preserve resolution kind, slug and provenance.",
+  "cases": [
+    {
+      "name": "registered explicit wins",
+      "projects": [{ "slug": "alpha", "member_paths": ["/workspace/alpha"], "member_repos": [] }],
+      "roots": ["/workspace/other"],
+      "explicit": "alpha",
+      "expected": { "kind": "resolved", "slug": "alpha", "source": "explicit" }
+    },
+    {
+      "name": "unknown explicit fails",
+      "projects": [],
+      "roots": ["/workspace/alpha"],
+      "explicit": "missing",
+      "expected": { "kind": "invalid_explicit", "slug": "missing" }
+    },
+    {
+      "name": "longest member path wins",
+      "projects": [
+        { "slug": "workspace", "member_paths": ["/workspace"], "member_repos": [] },
+        { "slug": "alpha", "member_paths": ["/workspace/alpha"], "member_repos": [] }
+      ],
+      "roots": ["/workspace/alpha/packages/app"],
+      "expected": { "kind": "resolved", "slug": "alpha", "source": "member_path" }
+    },
+    {
+      "name": "different registered roots are ambiguous",
+      "projects": [
+        { "slug": "alpha", "member_paths": ["/workspace/alpha"], "member_repos": [] },
+        { "slug": "beta", "member_paths": ["/workspace/beta"], "member_repos": [] }
+      ],
+      "roots": ["/workspace/alpha", "/workspace/beta"],
+      "expected": { "kind": "ambiguous", "slugs": ["alpha", "beta"] }
+    },
+    {
+      "name": "markerless unknown root is unresolved",
+      "projects": [],
+      "roots": ["/workspace/unknown"],
+      "expected": { "kind": "unresolved" }
+    }
+  ]
+}

--- a/tests/mcp/resolve-dir.test.ts
+++ b/tests/mcp/resolve-dir.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { existsSync, mkdtempSync, mkdirSync, realpathSync, symlinkSync } from "node:fs";
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { pathToFileURL } from "node:url";
@@ -48,9 +48,13 @@ describe("fallbackResolutionRoots", () => {
     expect(fallbackResolutionRoots(cwd)).toEqual({ kind: "resolved", paths: [realpathSync.native(cwd)] });
   });
 
-  it("rejects root, relative and missing cwd values", () => {
+  it("rejects root, relative, missing, and regular-file cwd values", () => {
+    const file = join(mkdtempSync(join(tmpdir(), "roots-file-")), "not-a-directory");
+    writeFileSync(file, "x");
+
     expect(fallbackResolutionRoots("/")).toEqual({ kind: "unresolved" });
     expect(fallbackResolutionRoots("relative/path")).toEqual({ kind: "unresolved" });
     expect(fallbackResolutionRoots(join(tmpdir(), "missing-roots-cwd"))).toEqual({ kind: "unresolved" });
+    expect(fallbackResolutionRoots(file)).toEqual({ kind: "unresolved" });
   });
 });

--- a/tests/mcp/resolve-dir.test.ts
+++ b/tests/mcp/resolve-dir.test.ts
@@ -1,15 +1,56 @@
-import { describe, it, expect } from "vitest";
-import { pickResolutionDir } from "../../src/mcp/resolve-dir.js";
+import { describe, expect, it } from "vitest";
+import { existsSync, mkdtempSync, mkdirSync, realpathSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { fallbackResolutionRoots, normalizeFileRoots } from "../../src/mcp/resolve-dir.js";
 
-describe("pickResolutionDir", () => {
-  it("prefers the first file:// client root over the fallback cwd", () => {
-    expect(pickResolutionDir([{ uri: "file:///Users/tim/Projects/Shelby" }], "/")).toBe("/Users/tim/Projects/Shelby");
+describe("normalizeFileRoots", () => {
+  it("decodes file URIs, removes trailing slashes and duplicates", () => {
+    const root = mkdtempSync(join(tmpdir(), "roots with spaces-"));
+    const uri = pathToFileURL(root).href;
+
+    expect(normalizeFileRoots([{ uri }, { uri: `${uri}/` }])).toEqual([realpathSync.native(root)]);
   });
-  it("falls back to cwd when there are no roots", () => {
-    expect(pickResolutionDir([], "/fallback")).toBe("/fallback");
-    expect(pickResolutionDir(undefined, "/fallback")).toBe("/fallback");
+
+  it("ignores malformed and non-file roots", () => {
+    expect(normalizeFileRoots([
+      { uri: "https://example.com/repo" },
+      { uri: "file:///tmp/%ZZ" },
+      { uri: "not a uri" },
+    ])).toEqual([]);
   });
-  it("ignores non-file roots", () => {
-    expect(pickResolutionDir([{ uri: "https://example.com" }], "/fallback")).toBe("/fallback");
+
+  it("canonicalizes existing symlinks", () => {
+    const container = mkdtempSync(join(tmpdir(), "roots-symlink-"));
+    const target = join(container, "target");
+    const link = join(container, "link");
+    mkdirSync(target);
+    symlinkSync(target, link);
+
+    expect(normalizeFileRoots([{ uri: pathToFileURL(link).href }])).toEqual([realpathSync.native(target)]);
+  });
+
+  it("keeps every distinct valid file root", () => {
+    const one = mkdtempSync(join(tmpdir(), "roots-one-"));
+    const two = mkdtempSync(join(tmpdir(), "roots-two-"));
+    expect(normalizeFileRoots([
+      { uri: pathToFileURL(one).href },
+      { uri: pathToFileURL(two).href },
+    ])).toEqual([realpathSync.native(one), realpathSync.native(two)]);
+  });
+});
+
+describe("fallbackResolutionRoots", () => {
+  it("uses an existing absolute cwd other than the filesystem root", () => {
+    const cwd = mkdtempSync(join(tmpdir(), "roots-cwd-"));
+    expect(existsSync(cwd)).toBe(true);
+    expect(fallbackResolutionRoots(cwd)).toEqual({ kind: "resolved", paths: [realpathSync.native(cwd)] });
+  });
+
+  it("rejects root, relative and missing cwd values", () => {
+    expect(fallbackResolutionRoots("/")).toEqual({ kind: "unresolved" });
+    expect(fallbackResolutionRoots("relative/path")).toEqual({ kind: "unresolved" });
+    expect(fallbackResolutionRoots(join(tmpdir(), "missing-roots-cwd"))).toEqual({ kind: "unresolved" });
   });
 });

--- a/tests/mcp/roots-integration.test.ts
+++ b/tests/mcp/roots-integration.test.ts
@@ -28,7 +28,9 @@ describe("initial MCP roots", () => {
     let release!: () => void;
     const gate = new Promise<void>((resolve) => { release = resolve; });
     const client = new Client({ name: "roots-client", version: "1.0.0" }, { capabilities: { roots: { listChanged: true } } });
+    let rootsRequests = 0;
     client.setRequestHandler(ListRootsRequestSchema, async () => {
+      rootsRequests += 1;
       await gate;
       return { roots: [{ uri: pathToFileURL(root).href, name: "scoped" }] };
     });
@@ -45,5 +47,10 @@ describe("initial MCP roots", () => {
     release();
     const result = await call;
     expect(result.isError).not.toBe(true);
+    expect(rootsRequests).toBe(1);
+
+    await client.sendRootsListChanged();
+    await client.callTool({ name: "list_thoughts", arguments: {} });
+    expect(rootsRequests).toBe(2);
   });
 });

--- a/tests/mcp/roots-integration.test.ts
+++ b/tests/mcp/roots-integration.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { ListRootsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { ThoughtDatabase } from "../../src/db/database.js";
+import { upsertProject } from "../../src/db/projects.js";
+import { createServerWithDb } from "../../src/mcp/server.js";
+
+let db: ThoughtDatabase | undefined;
+afterEach(() => db?.close());
+
+describe("initial MCP roots", () => {
+  it("awaits a delayed roots response before the first scoped tool call", async () => {
+    const root = mkdtempSync(join(tmpdir(), "roots-race-"));
+    mkdirSync(join(root, ".git"));
+    writeFileSync(join(root, ".git", "config"), '[remote "origin"]\n\turl = https://github.com/acme/scoped.git\n');
+
+    db = new ThoughtDatabase(":memory:");
+    upsertProject(db.db, { slug: "scoped", displayName: "Scoped", memberRepos: ["github.com/acme/scoped"], memberPaths: [], provisional: false });
+    const server = createServerWithDb(db);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    const client = new Client({ name: "roots-client", version: "1.0.0" }, { capabilities: { roots: { listChanged: true } } });
+    client.setRequestHandler(ListRootsRequestSchema, async () => {
+      await gate;
+      return { roots: [{ uri: pathToFileURL(root).href, name: "scoped" }] };
+    });
+    await client.connect(clientTransport);
+
+    let settled = false;
+    const call = client.callTool({ name: "list_thoughts", arguments: {} }).then((result) => {
+      settled = true;
+      return result;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(settled).toBe(false);
+
+    release();
+    const result = await call;
+    expect(result.isError).not.toBe(true);
+  });
+});

--- a/tests/mcp/scope-defaults.test.ts
+++ b/tests/mcp/scope-defaults.test.ts
@@ -40,16 +40,25 @@ describe("applyDefaultScope", () => {
     });
   });
 
-  it("rejects unknown and noncanonical explicit slugs", () => {
+  it("rejects unknown and noncanonical explicit slugs, including all-project reads", () => {
     upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: [], provisional: false });
     expect(applyDefaultScope({ project_identifier: "missing" }, db, [])).toMatchObject({ kind: "error", category: "project_scope_invalid" });
     expect(applyDefaultScope({ project_identifier: "Shelby" }, db, [])).toMatchObject({ kind: "error", category: "project_scope_invalid" });
+    expect(applyDefaultScope({ all_projects: true, project_identifier: "missing" }, db, [])).toMatchObject({
+      kind: "error", category: "project_scope_invalid",
+    });
   });
 
-  it("fails unresolved and ambiguous roots closed to shared-only", () => {
+  it("fails unresolved, ambiguous, and colliding roots closed to shared-only", () => {
     expect(argsOf(applyDefaultScope({ query: "hello" }, db, []))).toMatchObject({ shared_only: true, query: "hello" });
     const one = repo("https://github.com/acme/one.git");
     const two = repo("https://github.com/acme/two.git");
     expect(argsOf(applyDefaultScope({}, db, [one, two]))).toMatchObject({ shared_only: true });
+
+    upsertProject(db, {
+      slug: "shared-name", displayName: "Original", memberRepos: ["github.com/owner/shared-name"], memberPaths: [], provisional: false,
+    });
+    const collision = repo("https://gitlab.com/other/shared-name.git");
+    expect(argsOf(applyDefaultScope({}, db, [collision]))).toMatchObject({ shared_only: true });
   });
 });

--- a/tests/mcp/scope-defaults.test.ts
+++ b/tests/mcp/scope-defaults.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import Database from "better-sqlite3";
 import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -8,12 +8,8 @@ import { upsertProject } from "../../src/db/projects.js";
 import { applyDefaultScope } from "../../src/mcp/scope-defaults.js";
 
 let db: Database.Database;
-beforeEach(() => {
-  db = new Database(":memory:");
-  runMigrations(db);
-});
+beforeEach(() => { db = new Database(":memory:"); runMigrations(db); });
 
-/** Build a temp dir that looks like a git repo with the given remote. */
 function repo(remote: string): string {
   const root = mkdtempSync(join(tmpdir(), "sd-"));
   mkdirSync(join(root, ".git"));
@@ -21,101 +17,39 @@ function repo(remote: string): string {
   return root;
 }
 
-/** A non-project directory (no markers). */
-function plainDir(): string {
-  return mkdtempSync(join(tmpdir(), "sd-plain-"));
+function argsOf(result: ReturnType<typeof applyDefaultScope>) {
+  expect(result.kind).toBe("applied");
+  if (result.kind !== "applied") throw new Error(result.message);
+  return result.args;
 }
 
 describe("applyDefaultScope", () => {
-  it("injects project_identifier and include_shared when nothing is set and cwd resolves", () => {
-    upsertProject(db, {
-      slug: "shelby",
-      displayName: "Shelby",
-      memberRepos: ["github.com/Studio-Moser/Shelby-MCP"],
-      memberPaths: [],
-      provisional: false,
+  it("injects resolved project and shared records", () => {
+    upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: ["github.com/Studio-Moser/Shelby-MCP"], memberPaths: [], provisional: false });
+    expect(argsOf(applyDefaultScope({}, db, [repo("git@github.com:Studio-Moser/Shelby-MCP.git")]))).toMatchObject({
+      project_identifier: "shelby", include_shared: true,
     });
-    const cwd = repo("git@github.com:Studio-Moser/Shelby-MCP.git");
-
-    const result = applyDefaultScope({}, db, cwd);
-
-    expect(result.project_identifier).toBe("shelby");
-    expect(result.include_shared).toBe(true);
   });
 
-  it("leaves args unchanged when all_projects: true is set (opt-out)", () => {
-    upsertProject(db, {
-      slug: "shelby",
-      displayName: "Shelby",
-      memberRepos: ["github.com/Studio-Moser/Shelby-MCP"],
-      memberPaths: [],
-      provisional: false,
+  it("preserves all_projects and explicit include_shared", () => {
+    const all = { all_projects: true };
+    expect(argsOf(applyDefaultScope(all, db, []))).toBe(all);
+    upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: [], provisional: false });
+    expect(argsOf(applyDefaultScope({ project_identifier: "shelby", include_shared: false }, db, []))).toMatchObject({
+      project_identifier: "shelby", include_shared: false,
     });
-    const cwd = repo("git@github.com:Studio-Moser/Shelby-MCP.git");
-
-    const args = { all_projects: true };
-    const result = applyDefaultScope(args, db, cwd);
-
-    expect(result).toBe(args); // same reference — untouched
-    expect(result.project_identifier).toBeUndefined();
   });
 
-  it("leaves args unchanged when project_identifier is already explicitly set", () => {
-    upsertProject(db, {
-      slug: "shelby",
-      displayName: "Shelby",
-      memberRepos: ["github.com/Studio-Moser/Shelby-MCP"],
-      memberPaths: [],
-      provisional: false,
-    });
-    const cwd = repo("git@github.com:Studio-Moser/Shelby-MCP.git");
-
-    const args = { project_identifier: "other-project" };
-    const result = applyDefaultScope(args, db, cwd);
-
-    expect(result).toBe(args); // same reference — untouched
-    expect(result.project_identifier).toBe("other-project");
+  it("rejects unknown and noncanonical explicit slugs", () => {
+    upsertProject(db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: [], provisional: false });
+    expect(applyDefaultScope({ project_identifier: "missing" }, db, [])).toMatchObject({ kind: "error", category: "project_scope_invalid" });
+    expect(applyDefaultScope({ project_identifier: "Shelby" }, db, [])).toMatchObject({ kind: "error", category: "project_scope_invalid" });
   });
 
-  it("preserves existing include_shared value when injecting project_identifier", () => {
-    upsertProject(db, {
-      slug: "shelby",
-      displayName: "Shelby",
-      memberRepos: ["github.com/Studio-Moser/Shelby-MCP"],
-      memberPaths: [],
-      provisional: false,
-    });
-    const cwd = repo("git@github.com:Studio-Moser/Shelby-MCP.git");
-
-    const result = applyDefaultScope({ include_shared: false }, db, cwd);
-
-    expect(result.project_identifier).toBe("shelby");
-    // Caller explicitly set include_shared=false — that should be respected.
-    expect(result.include_shared).toBe(false);
-  });
-
-  it("falls back to shared-only (never global) when cwd does not resolve", () => {
-    const result = applyDefaultScope({ query: "hello" }, db, plainDir());
-    expect(result.project_identifier).toBeUndefined();
-    expect(result.shared_only).toBe(true);   // new fail-safe
-    expect(result.query).toBe("hello");
-  });
-
-  it("passes through other args fields unchanged when injecting scope", () => {
-    upsertProject(db, {
-      slug: "shelby",
-      displayName: "Shelby",
-      memberRepos: ["github.com/Studio-Moser/Shelby-MCP"],
-      memberPaths: [],
-      provisional: false,
-    });
-    const cwd = repo("git@github.com:Studio-Moser/Shelby-MCP.git");
-
-    const result = applyDefaultScope({ query: "auth", limit: 5, offset: 10 }, db, cwd);
-
-    expect(result.project_identifier).toBe("shelby");
-    expect(result.query).toBe("auth");
-    expect(result.limit).toBe(5);
-    expect(result.offset).toBe(10);
+  it("fails unresolved and ambiguous roots closed to shared-only", () => {
+    expect(argsOf(applyDefaultScope({ query: "hello" }, db, []))).toMatchObject({ shared_only: true, query: "hello" });
+    const one = repo("https://github.com/acme/one.git");
+    const two = repo("https://github.com/acme/two.git");
+    expect(argsOf(applyDefaultScope({}, db, [one, two]))).toMatchObject({ shared_only: true });
   });
 });

--- a/tests/tools/capture-scope.test.ts
+++ b/tests/tools/capture-scope.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ThoughtDatabase } from "../../src/db/database.js";
+import { getProjectBySlug, upsertProject } from "../../src/db/projects.js";
+import { resolveProjectScope } from "../../src/db/resolve-project.js";
+import { handleCaptureThought } from "../../src/tools/capture.js";
+
+let db: ThoughtDatabase;
+beforeEach(() => { db = new ThoughtDatabase(":memory:"); });
+
+function repo(remote: string): string {
+  const root = mkdtempSync(join(tmpdir(), "capture-scope-"));
+  mkdirSync(join(root, ".git"));
+  writeFileSync(join(root, ".git", "config"), `[remote "origin"]\n\turl = ${remote}\n`);
+  return root;
+}
+function count(): number { return (db.db.prepare("SELECT COUNT(*) AS n FROM thoughts").get() as { n: number }).n; }
+function error(result: ReturnType<typeof handleCaptureThought>): string {
+  const text = result.content[0]?.text;
+  if (!text) throw new Error("Expected an error result");
+  try {
+    return (JSON.parse(text) as { error: string }).error;
+  } catch {
+    throw new Error(`Expected JSON error result, received: ${text}`);
+  }
+}
+
+describe("capture project scope", () => {
+  it("accepts a registered explicit canonical slug", () => {
+    upsertProject(db.db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: [], provisional: false });
+    const result = handleCaptureThought(db, { content: "Scoped", project_identifier: "shelby" }, { kind: "unresolved" });
+    expect(result.isError).toBeUndefined();
+    expect(db.db.prepare("SELECT project_identifier FROM thoughts").get()).toEqual({ project_identifier: "shelby" });
+  });
+
+  it("rejects unknown and noncanonical explicit slugs without insertion", () => {
+    expect(error(handleCaptureThought(db, { content: "No", project_identifier: "missing" }, { kind: "unresolved" }))).toBe("project_scope_invalid");
+    expect(error(handleCaptureThought(db, { content: "No", project_identifier: "Bad Slug" }, { kind: "unresolved" }))).toBe("project_scope_invalid");
+    expect(count()).toBe(0);
+  });
+
+  it("rejects unresolved and ambiguous personal captures without insertion", () => {
+    expect(error(handleCaptureThought(db, { content: "No" }, { kind: "unresolved" }))).toBe("project_scope_unresolved");
+    expect(error(handleCaptureThought(db, { content: "No" }, { kind: "ambiguous", slugs: ["one", "two"] }))).toBe("project_scope_ambiguous");
+    expect(count()).toBe(0);
+  });
+
+  it("allows an explicitly shared capture without project roots", () => {
+    const result = handleCaptureThought(db, { content: "Shared", visibility: "shared" }, { kind: "unresolved" });
+    expect(result.isError).toBeUndefined();
+    expect(count()).toBe(1);
+  });
+
+  it("upserts a provisional project before inserting a derived personal capture", () => {
+    const root = repo("https://github.com/acme/new-project.git");
+    const scope = resolveProjectScope(db.db, [root]);
+    const result = handleCaptureThought(db, { content: "Personal" }, scope);
+    expect(result.isError).toBeUndefined();
+    expect(getProjectBySlug(db.db, "new-project")).toMatchObject({ provisional: true, memberRepos: ["github.com/acme/new-project"] });
+    expect(db.db.prepare("SELECT project_identifier FROM thoughts").get()).toEqual({ project_identifier: "new-project" });
+  });
+});

--- a/tests/tools/capture-scope.test.ts
+++ b/tests/tools/capture-scope.test.ts
@@ -61,4 +61,25 @@ describe("capture project scope", () => {
     expect(getProjectBySlug(db.db, "new-project")).toMatchObject({ provisional: true, memberRepos: ["github.com/acme/new-project"] });
     expect(db.db.prepare("SELECT project_identifier FROM thoughts").get()).toEqual({ project_identifier: "new-project" });
   });
+
+  it("rejects a derived slug collision without inserting or exposing the registered project", () => {
+    upsertProject(db.db, {
+      slug: "shared-name", displayName: "Original", memberRepos: ["github.com/owner/shared-name"], memberPaths: [], provisional: false,
+    });
+    const scope = resolveProjectScope(db.db, [repo("https://gitlab.com/other/shared-name.git")]);
+
+    expect(scope).toEqual({ kind: "unresolved" });
+    expect(error(handleCaptureThought(db, { content: "Wrong project" }, scope))).toBe("project_scope_unresolved");
+    expect(count()).toBe(0);
+    expect(getProjectBySlug(db.db, "shared-name")?.memberRepos).toEqual(["github.com/owner/shared-name"]);
+  });
+
+  it("rolls back provisional registration when thought insertion fails", () => {
+    const scope = resolveProjectScope(db.db, [repo("https://github.com/acme/atomic-project.git")]);
+    db.db.exec("CREATE TRIGGER reject_thought BEFORE INSERT ON thoughts BEGIN SELECT RAISE(ABORT, 'blocked'); END");
+
+    expect(() => handleCaptureThought(db, { content: "Personal" }, scope)).toThrow("blocked");
+    expect(getProjectBySlug(db.db, "atomic-project")).toBeNull();
+    expect(count()).toBe(0);
+  });
 });

--- a/tests/tools/capture.test.ts
+++ b/tests/tools/capture.test.ts
@@ -6,7 +6,8 @@ import { ThoughtDatabase } from "../../src/db/database.js";
 import { handleCaptureThought } from "../../src/tools/capture.js";
 import { getThought } from "../../src/db/thoughts.js";
 import { getEdgesBetween } from "../../src/db/edges.js";
-import { listProjects } from "../../src/db/projects.js";
+import { listProjects, upsertProject } from "../../src/db/projects.js";
+import { resolveProjectScope } from "../../src/db/resolve-project.js";
 
 function makeGitRepo(remote: string): string {
   const root = mkdtempSync(join(tmpdir(), "cap-"));
@@ -26,8 +27,14 @@ afterEach(() => {
 });
 
 function parseResult(result: object): any {
-  const r = result as any;
-  return JSON.parse(r.content[0].text);
+  const r = result as { content?: Array<{ text?: string }> };
+  const text = r.content?.[0]?.text;
+  if (!text) throw new Error("Expected tool result text");
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Expected JSON tool result: ${text}`, { cause: error });
+  }
 }
 
 describe("handleCaptureThought", () => {
@@ -121,7 +128,7 @@ describe("handleCaptureThought", () => {
     const result = handleCaptureThought(db, {});
     const r = result as any;
     expect(r.isError).toBe(true);
-    const data = JSON.parse(r.content[0].text);
+    const data = parseResult(result);
     expect(data.error).toBe("invalid_input");
   });
 
@@ -181,7 +188,7 @@ describe("handleCaptureThought", () => {
   it("stamps project_identifier from cwd when not provided explicitly", () => {
     const root = makeGitRepo("git@github.com:acme/My-Project.git");
     try {
-      const result = handleCaptureThought(db, { content: "Auto-resolved project" }, root);
+      const result = handleCaptureThought(db, { content: "Auto-resolved project" }, resolveProjectScope(db.db, [root]));
       const data = parseResult(result);
       const thought = getThought(db.db, data.id);
       expect(thought!.project_identifier).toBe("my-project");
@@ -214,12 +221,13 @@ describe("handleCaptureThought", () => {
     // Even when cwd is a temp git repo with an unknown remote, capturing with
     // an explicit project_identifier must skip the filesystem walk + registry write.
     const root = makeGitRepo("git@github.com:acme/UnknownProject.git");
+    upsertProject(db.db, { slug: "shelby", displayName: "Shelby", memberRepos: [], memberPaths: [], provisional: false });
     const beforeCount = listProjects(db.db).length;
     try {
       const result = handleCaptureThought(
         db,
         { content: "Explicit slug thought", project_identifier: "shelby" },
-        root,
+        resolveProjectScope(db.db, [root]),
       );
       expect(result.isError).toBeFalsy();
       const afterCount = listProjects(db.db).length;

--- a/tests/tools/context.test.ts
+++ b/tests/tools/context.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ThoughtDatabase } from "../../src/db/database.js";
 import { handleSelectContext } from "../../src/tools/context.js";
 import { handleCaptureThought } from "../../src/tools/capture.js";
+import { upsertProject } from "../../src/db/projects.js";
 
 let db: ThoughtDatabase;
 
@@ -14,11 +15,20 @@ afterEach(() => {
 });
 
 function parseResult(result: object): any {
-  const r = result as any;
-  return JSON.parse(r.content[0].text);
+  const text = (result as { content?: Array<{ text?: string }> }).content?.[0]?.text;
+  if (!text) throw new Error("Expected tool result text");
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Expected JSON tool result: ${text}`, { cause: error });
+  }
 }
 
 function capture(content: string, extra: Record<string, unknown> = {}): void {
+  const slug = extra.project_identifier;
+  if (typeof slug === "string") {
+    upsertProject(db.db, { slug, displayName: slug, memberRepos: [], memberPaths: [], provisional: false });
+  }
   handleCaptureThought(db, { content, ...extra });
 }
 

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -4,6 +4,7 @@ import { handleSearchThoughts } from "../../src/tools/search.js";
 import { handleCaptureThought } from "../../src/tools/capture.js";
 import { handleManageEdges } from "../../src/tools/graph.js";
 import { storeEmbedding } from "../../src/db/vectors.js";
+import { upsertProject } from "../../src/db/projects.js";
 
 let db: ThoughtDatabase;
 
@@ -16,11 +17,20 @@ afterEach(() => {
 });
 
 function parseResult(result: object): any {
-  const r = result as any;
-  return JSON.parse(r.content[0].text);
+  const text = (result as { content?: Array<{ text?: string }> }).content?.[0]?.text;
+  if (!text) throw new Error("Expected tool result text");
+  try {
+    return JSON.parse(text);
+  } catch (error) {
+    throw new Error(`Expected JSON tool result: ${text}`, { cause: error });
+  }
 }
 
 function captureId(content: string, extra: Record<string, unknown> = {}): string {
+  const slug = extra.project_identifier;
+  if (typeof slug === "string") {
+    upsertProject(db.db, { slug, displayName: slug, memberRepos: [], memberPaths: [], provisional: false });
+  }
   const result = handleCaptureThought(db, { content, ...extra });
   return parseResult(result).id;
 }


### PR DESCRIPTION
## What
- await and normalize every MCP client root before the first scoped tool call
- resolve registered explicit slugs, longest member paths, normalized remotes, worktrees, and multi-root ambiguity deterministically
- fail unresolved/ambiguous or colliding personal captures closed while allowing shared captures and transactionally provisioning detected projects
- add shared project-scope fixtures plus roots, resolver, read-scope, capture, rollback, and collision coverage

## Why
ShelbyMCP previously raced the first request against a fire-and-forget roots lookup and selected only one root. That could scope reads or captures from the server launch directory, create orphan project identifiers, or leak cross-project context.

## Testing
- `npm test` — 43 files, 467 tests passed
- `npm run build` — passed
- `npm run check` — passed
- `git diff main...HEAD --check` — passed
- independent review after fix round 1 — clean

Closes #29
Parent: Studio-Moser/Shelby-Docs#445
