### PR TITLE
Add expand_neighbors tool: one-call thought + neighbors

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -11,7 +11,11 @@ import { handleListThoughts } from "../tools/list.js";
 import { handleGetThought } from "../tools/get.js";
 import { handleUpdateThought } from "../tools/update.js";
 import { handleDeleteThought } from "../tools/delete.js";
-import { handleManageEdges, handleExploreGraph } from "../tools/graph.js";
+import {
+  handleManageEdges,
+  handleExploreGraph,
+  handleExpandNeighbors,
+} from "../tools/graph.js";
 import { handleThoughtStats } from "../tools/stats.js";
 import { handleGetBrief } from "../tools/brief.js";
 import { handleSelectContext } from "../tools/context.js";
@@ -455,6 +459,27 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       },
     },
     withLogging("explore_graph", (args) => handleExploreGraph(db, args as Record<string, unknown>)),
+  );
+
+  // --- expand_neighbors ---
+
+  server.registerTool(
+    "expand_neighbors",
+    {
+      title: "Expand Neighbors",
+      description: "Fetch a memory's full content together with summaries, types, and topics for its immediate graph neighbors. Use when an agent already has a thought ID and needs both that thought and its directly connected context in one call, instead of calling get_thought and explore_graph separately.",
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+      inputSchema: {
+        thought_id: z.string().describe("Thought ID to fetch and expand"),
+        limit: z.number().describe("Max neighbors to return (default 10, max 100)").optional(),
+      },
+    },
+    withLogging("expand_neighbors", (args) => handleExpandNeighbors(db, args as Record<string, unknown>)),
   );
 
   // --- thought_stats ---

--- a/src/tools/graph.ts
+++ b/src/tools/graph.ts
@@ -1,6 +1,7 @@
 import type { ThoughtDatabase } from "../db/database.js";
 import { linkThoughts, unlinkThoughts, expireEdge, VALID_EDGE_TYPES, traverseGraph } from "../db/edges.js";
-import { toolSuccess, toolError, type ToolResult } from "./helpers.js";
+import { getThought } from "../db/thoughts.js";
+import { clampLimit, toolSuccess, toolError, type ToolResult } from "./helpers.js";
 
 // --- manage_edges ---
 
@@ -117,5 +118,53 @@ export function handleExploreGraph(
     max_depth: depth,
     node_count: nodes.length,
     nodes,
+  });
+}
+
+// --- expand_neighbors ---
+
+interface ExpandNeighborsArgs {
+  thought_id: string;
+  limit?: number;
+}
+
+export function handleExpandNeighbors(
+  db: ThoughtDatabase,
+  args: Record<string, unknown>,
+): ToolResult {
+  const a = args as unknown as ExpandNeighborsArgs;
+
+  if (!a.thought_id || typeof a.thought_id !== "string") {
+    return toolError("invalid_input", "thought_id is required and must be a string");
+  }
+
+  const nodes = traverseGraph(db, a.thought_id, 1);
+  if (nodes.length === 0) {
+    return toolError(
+      "not_found",
+      `Thought "${a.thought_id}" not found. Try search_thoughts to find it by content.`,
+    );
+  }
+
+  const thought = getThought(db.db, a.thought_id)!;
+  const limit = clampLimit(a.limit, 10, 100);
+  const allNeighbors = nodes.filter((node) => node.depth !== 0);
+  const neighbors = allNeighbors
+    .slice(0, limit)
+    .map((node) => ({
+      id: node.id,
+      summary: node.summary,
+      type: node.type,
+      // ponytail: per-neighbor getThought is an N+1 capped at 100 rows on local
+      // SQLite; batch to one SELECT id, topics ... IN (...) if it ever shows up.
+      topics: getThought(db.db, node.id)!.topics,
+    }));
+
+  return toolSuccess({
+    id: thought.id,
+    content: thought.content,
+    summary: thought.summary,
+    neighbor_count: allNeighbors.length,
+    neighbors,
   });
 }

--- a/tests/mcp/integration.test.ts
+++ b/tests/mcp/integration.test.ts
@@ -44,14 +44,15 @@ describe("MCP Integration", () => {
     db?.close();
   });
 
-  // ---- 1. Lists all 11 tools ----
-  // (9 original memory tools + get_brief + select_context ported from the Mac app)
-  it("lists all 11 tools", async () => {
+  // ---- 1. Lists all 12 tools ----
+  // (9 original memory tools + get_brief + select_context + expand_neighbors ported from the Mac app)
+  it("lists all 12 tools", async () => {
     const { tools } = await client.listTools();
     const names = tools.map((t) => t.name).sort();
     expect(names).toEqual([
       "capture_thought",
       "delete_thought",
+      "expand_neighbors",
       "explore_graph",
       "get_brief",
       "get_thought",
@@ -62,7 +63,7 @@ describe("MCP Integration", () => {
       "thought_stats",
       "update_thought",
     ]);
-    expect(tools).toHaveLength(11);
+    expect(tools).toHaveLength(12);
   });
 
   it("exposes include_shared and applies shared/all-project brief scope", async () => {

--- a/tests/tools/graph.test.ts
+++ b/tests/tools/graph.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ThoughtDatabase } from "../../src/db/database.js";
-import { handleManageEdges, handleExploreGraph } from "../../src/tools/graph.js";
+import {
+  handleManageEdges,
+  handleExploreGraph,
+  handleExpandNeighbors,
+} from "../../src/tools/graph.js";
 import { handleCaptureThought } from "../../src/tools/capture.js";
 import { getEdgesBetween } from "../../src/db/edges.js";
 
@@ -209,4 +213,128 @@ describe("handleExploreGraph — include_expired", () => {
     const data = parseResult(result);
     expect(data.node_count).toBe(3);
   });
+});
+
+describe("handleExpandNeighbors", () => {
+  it("returns the thought and neighbors in both edge directions", () => {
+    const root = parseResult(handleCaptureThought(db, {
+      content: "Root content",
+      summary: "Root summary",
+    })).id;
+    const outgoing = parseResult(handleCaptureThought(db, {
+      content: "Outgoing content",
+      summary: "Outgoing summary",
+      type: "decision",
+      topics: ["outgoing"],
+    })).id;
+    const incoming = parseResult(handleCaptureThought(db, {
+      content: "Incoming content",
+      summary: "Incoming summary",
+      type: "reference",
+      topics: ["incoming"],
+    })).id;
+    handleManageEdges(db, {
+      action: "link",
+      source_id: root,
+      target_id: outgoing,
+      edge_type: "related",
+    });
+    handleManageEdges(db, {
+      action: "link",
+      source_id: incoming,
+      target_id: root,
+      edge_type: "cites",
+    });
+
+    const data = parseResult(handleExpandNeighbors(db, { thought_id: root }));
+
+    expect(data).toEqual({
+      id: root,
+      content: "Root content",
+      summary: "Root summary",
+      neighbor_count: 2,
+      neighbors: expect.arrayContaining([
+        {
+          id: outgoing,
+          summary: "Outgoing summary",
+          type: "decision",
+          topics: ["outgoing"],
+        },
+        {
+          id: incoming,
+          summary: "Incoming summary",
+          type: "reference",
+          topics: ["incoming"],
+        },
+      ]),
+    });
+    expect(data.neighbors).toHaveLength(2);
+  });
+
+  it("clamps the neighbor limit to 100", () => {
+    const root = captureId("Root");
+    for (let index = 0; index < 101; index += 1) {
+      const neighbor = captureId(`Neighbor ${index}`);
+      handleManageEdges(db, {
+        action: "link",
+        source_id: root,
+        target_id: neighbor,
+        edge_type: "related",
+      });
+    }
+
+    const data = parseResult(handleExpandNeighbors(db, {
+      thought_id: root,
+      limit: 200,
+    }));
+
+    expect(data.neighbors).toHaveLength(100);
+    expect(data.neighbor_count).toBe(101);
+  });
+
+  it("defaults the neighbor limit to 10", () => {
+    const root = captureId("Root");
+    for (let index = 0; index < 11; index += 1) {
+      const neighbor = captureId(`Neighbor ${index}`);
+      handleManageEdges(db, {
+        action: "link",
+        source_id: root,
+        target_id: neighbor,
+        edge_type: "related",
+      });
+    }
+
+    const data = parseResult(handleExpandNeighbors(db, { thought_id: root }));
+
+    expect(data.neighbors).toHaveLength(10);
+    expect(data.neighbor_count).toBe(11);
+  });
+
+  it("returns an empty neighbor list for an isolated thought", () => {
+    const root = captureId("Isolated");
+
+    const data = parseResult(handleExpandNeighbors(db, { thought_id: root }));
+
+    expect(data.neighbors).toEqual([]);
+  });
+
+  it("returns not_found for a non-existent thought", () => {
+    const result = handleExpandNeighbors(db, { thought_id: "nope" });
+    const data = parseResult(result);
+
+    expect(result.isError).toBe(true);
+    expect(data.error).toBe("not_found");
+    expect(data.message).toContain("search_thoughts");
+  });
+
+  it.each([{}, { thought_id: 42 }])(
+    "returns invalid_input for an invalid thought_id: %j",
+    (args) => {
+      const result = handleExpandNeighbors(db, args);
+      const data = parseResult(result);
+
+      expect(result.isError).toBe(true);
+      expect(data.error).toBe("invalid_input");
+    },
+  );
 });


### PR DESCRIPTION
## What
Adds an `expand_neighbors` MCP tool: one call returns a thought's full content plus `{ id, summary, type, topics }` for its immediate graph neighbors (`limit` default 10, max 100), with `neighbor_count` exposing the pre-truncation total. Registered in `server.ts` beside `explore_graph` with the same read-only annotations. Closes #26.

## Why
Parity with macOS #340 — agents currently need a `get_thought` + `explore_graph` round-trip to get a thought and its connected context. Pure convenience/efficiency parity, part of epic #17.

Implementation reuses `traverseGraph` (depth 1, dedup + temporal filter for free), `getThought`, and `clampLimit` — no new SQL. Per-neighbor topic lookups are a deliberate N+1 capped at 100 rows on local SQLite, marked with a `ponytail:` comment naming the batch-query upgrade path.

## Testing
- 6 new cases in `tests/tools/graph.test.ts`: both edge directions with exact response shape, limit clamp (200→100), default limit (11→10), `neighbor_count`, isolated thought, not_found, invalid_input.
- `tests/mcp/integration.test.ts` tool roster updated 11→12.
- `npx vitest run`: **540/540 passed**. `npm run check` (tsc + eslint): exit 0.
- Reviewed by an independent model pass: no blockers; both suggestions (truncation signal, default-limit test) applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)