### PR TITLE
Memory-engine parity wave 1: reconfirm, reinforcement, vocab, topics, telemetry, write-path reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Schema migrations v9-v11, aligned with Shelby-MacOS: local search telemetry, the local feedback log, and thought re-confirmation timestamps.
+- `capture_thought` responses now include an `action` describing whether the thought was created, reinforced as a duplicate, or returned with relationship suggestions.
+- `search_thoughts` now accepts a canonicalized `topic` filter.
 - Canonical immutable project UUIDs, alias-aware project resolution, and additive `project_id` inputs and outputs for project-scoped MCP tools.
 - Curated `get_brief` policy with trusted exact-project/shared eligibility, sensitivity and prompt-injection filtering, consolidation/refutation handling, deterministic role lanes, summary deduplication, an 800-token default budget, structured items, and omission diagnostics. The MCP schema now exposes `include_shared`; `select_context` reuses the same curated essentials policy.
 - Claim-scoped refutation. A `refuted_by` edge whose `metadata` carries a non-empty string `claim` now supersedes **only that claim**: the source thought stays brief-eligible and renders as `- <summary> (superseded: <claim>)`. `get_brief` items gain a `refuted_claims` array. Previously refutation was all-or-nothing, so correcting one claim in a multi-claim thought dropped every still-valid claim it carried out of every brief. See [ADR 0001 §5a](https://github.com/Studio-Moser/Shelby-Docs/blob/main/docs/adr/0001-memory-server-architecture-contract.md).
 
 ### Changed
 
+- `get_thought` now reinforces the retrieved thought and returns its updated reinforcement count.
+- The legacy `preference` thought type is normalized to `decision` on both capture and update.
 - **Breaking (output shape):** `get_brief` items now always include a `refuted_claims` array, and a thought carrying a scoped refutation renders with a `(superseded: …)` caveat appended to its line. Consumers that parse brief markdown or item objects should tolerate both. `policy_version` bumped 1 → 2 to signal the change; the canonical cross-codebase fixture is at `fixture_version` 2.
 - A `refuted_by` edge with no `claim`, a blank `claim`, or a non-string `claim` continues to refute the whole thought. Existing edges carry no `metadata`, so stored data and current behaviour are unaffected.
 - Claim text passes the same normalization, prompt-injection and PII gate as summaries before reaching a brief; a claim that fails the gate is dropped without affecting its thought's eligibility.

--- a/src/db/brief-candidates.ts
+++ b/src/db/brief-candidates.ts
@@ -90,7 +90,9 @@ const VALID_EXPLICIT_METADATA = `json_valid(t.metadata)
       json_extract(t.metadata, '$.extra.sensitivity') = 'normal')
   )`;
 
-const LEGACY_SAFE = `t.type IN ('decision', 'reference', 'insight')
+// `preference` is retained as a legacy alias for rows captured before preferences
+// were folded into the canonical `decision` type.
+const LEGACY_SAFE = `t.type IN ('decision', 'reference', 'insight', 'preference')
   AND json_valid(t.metadata)
   AND json_type(t.metadata) = 'object'
   AND (

--- a/src/db/fts.ts
+++ b/src/db/fts.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { canonicalizeTopic } from "./topic-canonicalization.js";
 
 export interface SearchResult {
   id: string;
@@ -20,6 +21,7 @@ export interface SearchOptions {
   project_id?: string;
   include_shared?: boolean;
   shared_only?: boolean;
+	topic?: string;
 }
 
 export interface SearchListResult {
@@ -64,6 +66,10 @@ export function searchThoughts(
     whereClauses.push("t.project = ?");
     params.push(options.project);
   }
+	if (options.topic) {
+		whereClauses.push("t.topics LIKE ?");
+		params.push(`%"${canonicalizeTopic(options.topic)}"%`);
+	}
   if (options.shared_only) {
     whereClauses.push("t.visibility = 'shared'");
   }

--- a/src/db/fts.ts
+++ b/src/db/fts.ts
@@ -1,5 +1,5 @@
 import type Database from "better-sqlite3";
-import { canonicalizeTopic } from "./topic-canonicalization.js";
+import { topicLikePattern } from "./topic-canonicalization.js";
 
 export interface SearchResult {
   id: string;
@@ -68,7 +68,7 @@ export function searchThoughts(
   }
 	if (options.topic) {
 		whereClauses.push("t.topics LIKE ?");
-		params.push(`%"${canonicalizeTopic(options.topic)}"%`);
+		params.push(topicLikePattern(options.topic));
 	}
   if (options.shared_only) {
     whereClauses.push("t.visibility = 'shared'");

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -262,6 +262,33 @@ const migrations: Migration[] = [
 			);
     },
   },
+	{
+		version: 9,
+		description: "Track thought re-confirmation timestamps",
+		up: (db) => {
+			db.exec("ALTER TABLE thoughts ADD COLUMN last_confirmed_at TEXT");
+		},
+	},
+	{
+		version: 10,
+		description: "Local search telemetry and rediscovery tracking",
+		up: (db) => {
+			// Local-only diagnostic data: this table is not part of any sync path.
+			db.exec(`
+				CREATE TABLE search_telemetry (
+					id                 TEXT PRIMARY KEY,
+					created_at         TEXT NOT NULL,
+					query_hash         TEXT NOT NULL,
+					mode               TEXT NOT NULL,
+					result_count       INTEGER NOT NULL,
+					top_ids            TEXT NOT NULL,
+					rediscovery        INTEGER NOT NULL,
+					project_identifier TEXT
+				);
+				CREATE INDEX idx_search_telemetry_created_at ON search_telemetry(created_at);
+			`);
+		},
+	},
 ];
 
 export function getSchemaVersion(db: Database.Database): number {

--- a/src/db/migrations.ts
+++ b/src/db/migrations.ts
@@ -7,6 +7,8 @@ export interface Migration {
   up: (db: Database.Database) => void;
 }
 
+export const CURRENT_SCHEMA_VERSION = 11;
+
 const migrations: Migration[] = [
   {
     version: 1,
@@ -264,29 +266,47 @@ const migrations: Migration[] = [
   },
 	{
 		version: 9,
-		description: "Track thought re-confirmation timestamps",
-		up: (db) => {
-			db.exec("ALTER TABLE thoughts ADD COLUMN last_confirmed_at TEXT");
-		},
-	},
-	{
-		version: 10,
 		description: "Local search telemetry and rediscovery tracking",
 		up: (db) => {
 			// Local-only diagnostic data: this table is not part of any sync path.
 			db.exec(`
-				CREATE TABLE search_telemetry (
-					id                 TEXT PRIMARY KEY,
-					created_at         TEXT NOT NULL,
-					query_hash         TEXT NOT NULL,
-					mode               TEXT NOT NULL,
-					result_count       INTEGER NOT NULL,
-					top_ids            TEXT NOT NULL,
-					rediscovery        INTEGER NOT NULL,
+				CREATE TABLE IF NOT EXISTS search_telemetry (
+					id TEXT PRIMARY KEY,
+					created_at TEXT NOT NULL,
+					query_hash TEXT,
+					mode TEXT,
+					result_count INTEGER NOT NULL DEFAULT 0,
+					top_ids TEXT,
+					rediscovery INTEGER NOT NULL DEFAULT 0,
 					project_identifier TEXT
 				);
-				CREATE INDEX idx_search_telemetry_created_at ON search_telemetry(created_at);
+				CREATE INDEX IF NOT EXISTS idx_search_telemetry_created ON search_telemetry(created_at);
 			`);
+		},
+	},
+	{
+		version: 10,
+		description: "Local KTO-shaped feedback log",
+		up: (db) => {
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS feedback (
+					id TEXT PRIMARY KEY,
+					created_at TEXT NOT NULL,
+					feature TEXT NOT NULL,
+					variant_id TEXT,
+					label TEXT NOT NULL,
+					prompt_hash TEXT,
+					response_hash TEXT
+				);
+				CREATE INDEX IF NOT EXISTS idx_feedback_variant ON feedback(variant_id);
+			`);
+		},
+	},
+	{
+		version: 11,
+		description: "Track thought re-confirmation timestamps",
+		up: (db) => {
+			db.exec("ALTER TABLE thoughts ADD COLUMN last_confirmed_at TEXT");
 		},
 	},
 ];

--- a/src/db/reconciliation.ts
+++ b/src/db/reconciliation.ts
@@ -1,0 +1,122 @@
+import type Database from "better-sqlite3";
+
+const MIN_TOKENS = 4;
+const NOOP_THRESHOLD = 0.9;
+const AUTO_EDGE_THRESHOLD = 0.8;
+const SUGGEST_THRESHOLD = 0.3;
+const CANDIDATE_LIMIT = 20;
+
+export interface ReconciliationCandidate {
+	id: string;
+	content: string;
+	type?: string;
+	summary?: string | null;
+	topics?: string[];
+	people?: string[];
+}
+
+export interface SuggestedEdge {
+	id: string;
+	similarity: number;
+	autoApply: boolean;
+}
+
+export type ReconciliationDecision =
+	| { action: "noop"; existingId: string; suggestedEdges: [] }
+	| { action: "add"; suggestedEdges: SuggestedEdge[] };
+
+function tokens(content: string): Set<string> {
+	return new Set(content.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []);
+}
+
+function jaccard(left: Set<string>, right: Set<string>): number {
+	let intersection = 0;
+	for (const token of left) if (right.has(token)) intersection++;
+	return intersection / (left.size + right.size - intersection);
+}
+
+export function reconcile(
+	content: string,
+	type: string,
+	candidates: ReconciliationCandidate[],
+): ReconciliationDecision {
+	const inputTokens = tokens(content);
+	if (inputTokens.size < MIN_TOKENS) return { action: "add", suggestedEdges: [] };
+
+	const scored = candidates.flatMap((candidate) => {
+		if (candidate.type !== undefined && candidate.type !== type) return [];
+		const candidateTokens = tokens(candidate.content);
+		if (candidateTokens.size < MIN_TOKENS) return [];
+		return [{
+			id: candidate.id,
+			similarity: jaccard(inputTokens, candidateTokens),
+			autoApply: false,
+		}];
+	}).sort((left, right) => right.similarity - left.similarity || left.id.localeCompare(right.id));
+
+	const duplicate = scored.find(({ similarity }) => similarity >= NOOP_THRESHOLD);
+	if (duplicate) {
+		return { action: "noop", existingId: duplicate.id, suggestedEdges: [] };
+	}
+
+	return {
+		action: "add",
+		suggestedEdges: scored
+			.filter(({ similarity }) => similarity >= SUGGEST_THRESHOLD)
+			.map((edge) => ({
+				...edge,
+				autoApply: edge.similarity >= AUTO_EDGE_THRESHOLD,
+			})),
+	};
+}
+
+function parseArray(raw: string | null): string[] {
+	if (!raw) return [];
+	try {
+		const value: unknown = JSON.parse(raw);
+		return Array.isArray(value)
+			? value.filter((item): item is string => typeof item === "string")
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+export function findReconciliationCandidates(
+	db: Database.Database,
+	content: string,
+	type: string,
+	projectIdentifier: string | null,
+): ReconciliationCandidate[] {
+	const inputTokens = tokens(content);
+	if (inputTokens.size < MIN_TOKENS) return [];
+	const ftsQuery = [...inputTokens].map((token) => `"${token}"`).join(" OR ");
+	const rows = db.prepare(
+		`SELECT t.id, t.content, t.type, t.summary, t.topics, t.people
+		 FROM thoughts_fts
+		 JOIN thoughts t ON thoughts_fts.rowid = t.rowid
+		 WHERE thoughts_fts MATCH @query
+		   AND t.type = @type
+		   AND (t.project_identifier = @project_identifier
+		        OR (t.project_identifier IS NULL AND @project_identifier IS NULL))
+		 ORDER BY rank
+		 LIMIT @limit`,
+	).all({
+		query: ftsQuery,
+		type,
+		project_identifier: projectIdentifier,
+		limit: CANDIDATE_LIMIT,
+	}) as Array<{
+		id: string;
+		content: string;
+		type: string;
+		summary: string | null;
+		topics: string | null;
+		people: string | null;
+	}>;
+	return rows.map((row) => ({
+		...row,
+		topics: parseArray(row.topics),
+		people: parseArray(row.people),
+	}));
+}

--- a/src/db/reconciliation.ts
+++ b/src/db/reconciliation.ts
@@ -1,4 +1,5 @@
 import type Database from "better-sqlite3";
+import { sanitizeFTSQuery } from "./fts.js";
 
 const MIN_TOKENS = 4;
 const NOOP_THRESHOLD = 0.9;
@@ -9,10 +10,8 @@ const CANDIDATE_LIMIT = 20;
 export interface ReconciliationCandidate {
 	id: string;
 	content: string;
-	type?: string;
+	type: string;
 	summary?: string | null;
-	topics?: string[];
-	people?: string[];
 }
 
 export interface SuggestedEdge {
@@ -25,11 +24,11 @@ export type ReconciliationDecision =
 	| { action: "noop"; existingId: string; suggestedEdges: [] }
 	| { action: "add"; suggestedEdges: SuggestedEdge[] };
 
-function tokens(content: string): Set<string> {
+export function tokenize(content: string): Set<string> {
 	return new Set(content.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? []);
 }
 
-function jaccard(left: Set<string>, right: Set<string>): number {
+function jaccard(left: ReadonlySet<string>, right: ReadonlySet<string>): number {
 	let intersection = 0;
 	for (const token of left) if (right.has(token)) intersection++;
 	return intersection / (left.size + right.size - intersection);
@@ -39,22 +38,22 @@ export function reconcile(
 	content: string,
 	type: string,
 	candidates: ReconciliationCandidate[],
+	inputTokens: ReadonlySet<string> = tokenize(content),
 ): ReconciliationDecision {
-	const inputTokens = tokens(content);
 	if (inputTokens.size < MIN_TOKENS) return { action: "add", suggestedEdges: [] };
 
-	const scored = candidates.flatMap((candidate) => {
-		if (candidate.type !== undefined && candidate.type !== type) return [];
-		const candidateTokens = tokens(candidate.content);
-		if (candidateTokens.size < MIN_TOKENS) return [];
-		return [{
+	const scored = candidates.map((candidate) => {
+		const candidateTokens = tokenize(candidate.content);
+		return {
 			id: candidate.id,
 			similarity: jaccard(inputTokens, candidateTokens),
-			autoApply: false,
-		}];
+			type: candidate.type,
+		};
 	}).sort((left, right) => right.similarity - left.similarity || left.id.localeCompare(right.id));
 
-	const duplicate = scored.find(({ similarity }) => similarity >= NOOP_THRESHOLD);
+	const duplicate = scored.find(({ similarity, type: candidateType }) =>
+		candidateType === type && similarity >= NOOP_THRESHOLD,
+	);
 	if (duplicate) {
 		return { action: "noop", existingId: duplicate.id, suggestedEdges: [] };
 	}
@@ -63,60 +62,56 @@ export function reconcile(
 		action: "add",
 		suggestedEdges: scored
 			.filter(({ similarity }) => similarity >= SUGGEST_THRESHOLD)
-			.map((edge) => ({
-				...edge,
-				autoApply: edge.similarity >= AUTO_EDGE_THRESHOLD,
+			.map(({ id, similarity }) => ({
+				id,
+				similarity,
+				autoApply: similarity >= AUTO_EDGE_THRESHOLD,
 			})),
 	};
-}
-
-function parseArray(raw: string | null): string[] {
-	if (!raw) return [];
-	try {
-		const value: unknown = JSON.parse(raw);
-		return Array.isArray(value)
-			? value.filter((item): item is string => typeof item === "string")
-			: [];
-	} catch {
-		return [];
-	}
 }
 
 export function findReconciliationCandidates(
 	db: Database.Database,
 	content: string,
-	type: string,
-	projectIdentifier: string | null,
+	summary: string | undefined,
+	projectId: string | null,
+	project: string | null,
+	inputTokens: ReadonlySet<string> = tokenize(content),
 ): ReconciliationCandidate[] {
-	const inputTokens = tokens(content);
 	if (inputTokens.size < MIN_TOKENS) return [];
-	const ftsQuery = [...inputTokens].map((token) => `"${token}"`).join(" OR ");
+	const searchText = summary?.trim() ? summary : content.slice(0, 200);
+	const ftsQuery = sanitizeFTSQuery(searchText);
+	if (ftsQuery === "") return [];
+	if (projectId === null && project !== null) return [];
+	const scopeClause = projectId === null
+		? `t.project_id IS NULL
+		   AND t.project_identifier IS NULL
+		   AND t.project IS NULL
+		   AND t.visibility = 'personal'`
+		: `t.visibility != 'shared'
+		   AND t.project_id = @project_id
+		   AND (t.project_identifier IS NULL OR EXISTS (
+		     SELECT 1 FROM project_slug_aliases alias
+		     WHERE alias.slug = t.project_identifier
+		       AND alias.project_id = t.project_id
+		   ))`;
 	const rows = db.prepare(
-		`SELECT t.id, t.content, t.type, t.summary, t.topics, t.people
+		`SELECT t.id, t.content, t.type, t.summary
 		 FROM thoughts_fts
 		 JOIN thoughts t ON thoughts_fts.rowid = t.rowid
 		 WHERE thoughts_fts MATCH @query
-		   AND t.type = @type
-		   AND (t.project_identifier = @project_identifier
-		        OR (t.project_identifier IS NULL AND @project_identifier IS NULL))
+		   AND ${scopeClause}
 		 ORDER BY rank
 		 LIMIT @limit`,
 	).all({
 		query: ftsQuery,
-		type,
-		project_identifier: projectIdentifier,
+		project_id: projectId,
 		limit: CANDIDATE_LIMIT,
 	}) as Array<{
 		id: string;
 		content: string;
 		type: string;
 		summary: string | null;
-		topics: string | null;
-		people: string | null;
 	}>;
-	return rows.map((row) => ({
-		...row,
-		topics: parseArray(row.topics),
-		people: parseArray(row.people),
-	}));
+	return rows;
 }

--- a/src/db/search-telemetry.ts
+++ b/src/db/search-telemetry.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import type Database from "better-sqlite3";
 import { v4 as uuidv4 } from "uuid";
+import { parseJsonArray } from "./thoughts.js";
 
 export type SearchMode = "fts" | "vector" | "hybrid";
 
@@ -14,16 +15,29 @@ export function isRediscovery(
 	return overlap / previous.size > 0.5;
 }
 
-function parseTopIds(raw: string | undefined): string[] {
-	if (!raw) return [];
-	try {
-		const value: unknown = JSON.parse(raw);
-		return Array.isArray(value)
-			? value.filter((id): id is string => typeof id === "string")
-			: [];
-	} catch {
-		return [];
-	}
+interface TelemetryStatements {
+	loadPrevious: Database.Statement;
+	insert: Database.Statement;
+	previousTopIds?: string[];
+}
+
+const statementCache = new WeakMap<Database.Database, TelemetryStatements>();
+
+function statementsFor(db: Database.Database): TelemetryStatements {
+	const cached = statementCache.get(db);
+	if (cached) return cached;
+	const statements = {
+		loadPrevious: db.prepare(
+			"SELECT top_ids FROM search_telemetry ORDER BY created_at DESC, rowid DESC LIMIT 1",
+		),
+		insert: db.prepare(
+			`INSERT INTO search_telemetry
+			 (id, created_at, query_hash, mode, result_count, top_ids, rediscovery, project_identifier)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+		),
+	};
+	statementCache.set(db, statements);
+	return statements;
 }
 
 export function recordSearchTelemetry(
@@ -36,15 +50,15 @@ export function recordSearchTelemetry(
 		projectIdentifier: string | null;
 	},
 ): void {
-	const previous = db.prepare(
-		"SELECT top_ids FROM search_telemetry ORDER BY created_at DESC, rowid DESC LIMIT 1",
-	).get() as { top_ids: string } | undefined;
-	const rediscovery = isRediscovery(input.topIds, parseTopIds(previous?.top_ids));
-	db.prepare(
-		`INSERT INTO search_telemetry
-		 (id, created_at, query_hash, mode, result_count, top_ids, rediscovery, project_identifier)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-	).run(
+	const statements = statementsFor(db);
+	if (statements.previousTopIds === undefined) {
+		const previous = statements.loadPrevious.get() as
+			| { top_ids: string | null }
+			| undefined;
+		statements.previousTopIds = parseJsonArray(previous?.top_ids ?? null);
+	}
+	const rediscovery = isRediscovery(input.topIds, statements.previousTopIds);
+	statements.insert.run(
 		uuidv4(),
 		new Date().toISOString(),
 		createHash("sha256").update(input.query).digest("hex"),
@@ -54,4 +68,5 @@ export function recordSearchTelemetry(
 		rediscovery ? 1 : 0,
 		input.projectIdentifier,
 	);
+	statements.previousTopIds = [...input.topIds];
 }

--- a/src/db/search-telemetry.ts
+++ b/src/db/search-telemetry.ts
@@ -1,0 +1,57 @@
+import { createHash } from "node:crypto";
+import type Database from "better-sqlite3";
+import { v4 as uuidv4 } from "uuid";
+
+export type SearchMode = "fts" | "vector" | "hybrid";
+
+export function isRediscovery(
+	currentTopIds: string[],
+	previousTopIds: string[],
+): boolean {
+	const previous = new Set(previousTopIds);
+	if (previous.size === 0) return false;
+	const overlap = new Set(currentTopIds.filter((id) => previous.has(id))).size;
+	return overlap / previous.size > 0.5;
+}
+
+function parseTopIds(raw: string | undefined): string[] {
+	if (!raw) return [];
+	try {
+		const value: unknown = JSON.parse(raw);
+		return Array.isArray(value)
+			? value.filter((id): id is string => typeof id === "string")
+			: [];
+	} catch {
+		return [];
+	}
+}
+
+export function recordSearchTelemetry(
+	db: Database.Database,
+	input: {
+		query: string;
+		mode: SearchMode;
+		resultCount: number;
+		topIds: string[];
+		projectIdentifier: string | null;
+	},
+): void {
+	const previous = db.prepare(
+		"SELECT top_ids FROM search_telemetry ORDER BY created_at DESC, rowid DESC LIMIT 1",
+	).get() as { top_ids: string } | undefined;
+	const rediscovery = isRediscovery(input.topIds, parseTopIds(previous?.top_ids));
+	db.prepare(
+		`INSERT INTO search_telemetry
+		 (id, created_at, query_hash, mode, result_count, top_ids, rediscovery, project_identifier)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+	).run(
+		uuidv4(),
+		new Date().toISOString(),
+		createHash("sha256").update(input.query).digest("hex"),
+		input.mode,
+		input.resultCount,
+		JSON.stringify(input.topIds),
+		rediscovery ? 1 : 0,
+		input.projectIdentifier,
+	);
+}

--- a/src/db/thoughts.ts
+++ b/src/db/thoughts.ts
@@ -1,6 +1,9 @@
 import type Database from "better-sqlite3";
 import { v4 as uuidv4 } from "uuid";
-import { canonicalizeTopic } from "./topic-canonicalization.js";
+import {
+	canonicalizeTopics,
+	topicLikePattern,
+} from "./topic-canonicalization.js";
 
 export type TrustLevel = "trusted" | "unverified" | "external";
 
@@ -111,11 +114,13 @@ interface RawSummaryRow {
   created_at: string;
 }
 
-function parseJsonArray(raw: string | null): string[] {
+export function parseJsonArray(raw: string | null): string[] {
   if (!raw) return [];
   try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
+		const parsed: unknown = JSON.parse(raw);
+		return Array.isArray(parsed)
+			? parsed.filter((item): item is string => typeof item === "string")
+			: [];
   } catch {
     return [];
   }
@@ -195,7 +200,7 @@ export function insertThought(db: Database.Database, input: ThoughtInput): strin
     project: input.project ?? null,
     project_id: input.project_id ?? project?.project_id ?? null,
     project_identifier: project?.current_slug ?? input.project_identifier ?? null,
-    topics: input.topics ? JSON.stringify(input.topics) : null,
+    topics: input.topics ? JSON.stringify(canonicalizeTopics(input.topics)) : null,
     people: input.people ? JSON.stringify(input.people) : null,
     visibility: input.visibility ?? "personal",
     metadata: input.metadata ? JSON.stringify(input.metadata) : null,
@@ -225,6 +230,7 @@ export function incrementReinforcement(
 	const result = db.prepare(
 		`UPDATE thoughts
 		 SET reinforcement_count = reinforcement_count + @amount,
+		     updated_at = @now,
 		     last_confirmed_at = CASE WHEN @confirm = 1 THEN @now ELSE last_confirmed_at END
 		 WHERE id = @id`,
 	).run({ id, amount, confirm: confirm ? 1 : 0, now: new Date().toISOString() });
@@ -269,7 +275,7 @@ export function updateThought(
   }
   if (updates.topics !== undefined) {
     setClauses.push("topics = @topics");
-    params.topics = JSON.stringify(updates.topics);
+		params.topics = JSON.stringify(canonicalizeTopics(updates.topics));
   }
   if (updates.people !== undefined) {
     setClauses.push("people = @people");
@@ -332,7 +338,7 @@ export function listThoughts(db: Database.Database, options: ListOptions = {}): 
   }
   if (options.topic) {
     whereClauses.push("topics LIKE @topic");
-		params.topic = `%"${canonicalizeTopic(options.topic)}"%`;
+		params.topic = topicLikePattern(options.topic);
   }
   if (options.person) {
     whereClauses.push("people LIKE @person");

--- a/src/db/thoughts.ts
+++ b/src/db/thoughts.ts
@@ -1,5 +1,6 @@
 import type Database from "better-sqlite3";
 import { v4 as uuidv4 } from "uuid";
+import { canonicalizeTopic } from "./topic-canonicalization.js";
 
 export type TrustLevel = "trusted" | "unverified" | "external";
 
@@ -39,6 +40,7 @@ export interface ThoughtRecord {
   updated_at: string;
   consolidated_into: string | null;
   reinforcement_count: number;
+	last_confirmed_at: string | null;
 }
 
 export interface ThoughtSummary {
@@ -96,6 +98,7 @@ interface RawThoughtRow {
   updated_at: string;
   consolidated_into: string | null;
   reinforcement_count: number;
+	last_confirmed_at: string | null;
 }
 
 interface RawSummaryRow {
@@ -151,6 +154,7 @@ function rowToRecord(row: RawThoughtRow): ThoughtRecord {
     updated_at: row.updated_at,
     consolidated_into: row.consolidated_into,
     reinforcement_count: row.reinforcement_count,
+		last_confirmed_at: row.last_confirmed_at,
   };
 }
 
@@ -210,6 +214,21 @@ export function getThought(db: Database.Database, id: string): ThoughtRecord | n
   `).get(id) as RawThoughtRow | undefined;
   if (!row) return null;
   return rowToRecord(row);
+}
+
+export function incrementReinforcement(
+	db: Database.Database,
+	id: string,
+	amount = 1,
+	confirm = false,
+): boolean {
+	const result = db.prepare(
+		`UPDATE thoughts
+		 SET reinforcement_count = reinforcement_count + @amount,
+		     last_confirmed_at = CASE WHEN @confirm = 1 THEN @now ELSE last_confirmed_at END
+		 WHERE id = @id`,
+	).run({ id, amount, confirm: confirm ? 1 : 0, now: new Date().toISOString() });
+	return result.changes > 0;
 }
 
 export function updateThought(
@@ -313,7 +332,7 @@ export function listThoughts(db: Database.Database, options: ListOptions = {}): 
   }
   if (options.topic) {
     whereClauses.push("topics LIKE @topic");
-    params.topic = `%"${options.topic}"%`;
+		params.topic = `%"${canonicalizeTopic(options.topic)}"%`;
   }
   if (options.person) {
     whereClauses.push("people LIKE @person");

--- a/src/db/topic-canonicalization.ts
+++ b/src/db/topic-canonicalization.ts
@@ -13,3 +13,7 @@ export function canonicalizeTopics(topics: string[]): string[] {
 	}
 	return canonical;
 }
+
+export function topicLikePattern(topic: string): string {
+	return `%"${canonicalizeTopic(topic)}"%`;
+}

--- a/src/db/topic-canonicalization.ts
+++ b/src/db/topic-canonicalization.ts
@@ -1,0 +1,15 @@
+export function canonicalizeTopic(topic: string): string {
+	return topic.trim().toLowerCase().replace(/[\s_-]+/g, "-");
+}
+
+export function canonicalizeTopics(topics: string[]): string[] {
+	const seen = new Set<string>();
+	const canonical: string[] = [];
+	for (const topic of topics) {
+		const value = canonicalizeTopic(topic);
+		if (!value || seen.has(value)) continue;
+		seen.add(value);
+		canonical.push(value);
+	}
+	return canonical;
+}

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -162,7 +162,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
         content: z.string().max(MAX_CONTENT_LENGTH).describe("The thought content").optional(),
         summary: z.string().max(MAX_SUMMARY_LENGTH).describe("One-line summary for search results").optional(),
         type: z
-          .enum(["note", "decision", "task", "question", "reference", "insight"])
+          .enum(["note", "decision", "task", "question", "reference", "insight", "preference"])
           .describe("Thought type")
           .optional(),
         source: z.string().describe("Source tool or context").optional(),
@@ -269,6 +269,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
         limit: z.number().describe("Max results (default 20, max 100)").optional(),
         offset: z.number().describe("Pagination offset").optional(),
         type: z.string().describe("Filter by thought type").optional(),
+		topic: z.string().describe("Filter by topic").optional(),
         project: z.string().describe("Filter by project").optional(),
         project_id: projectIdSchema.optional(),
         project_identifier: z.string().describe("Scope to project slug (use with include_shared to also include shared thoughts; auto-defaulted from cwd when omitted)").optional(),

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -255,7 +255,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       title: "Search Thoughts",
       description: "Search long-term memory by keyword (FTS) or vector similarity, or both (hybrid). Call this before starting any task, making any decision, or when the user asks what you remember about a topic. Returns matching thought summaries with IDs — call get_thought to read full content. Supports graph_depth for GraphRAG-style retrieval: after FTS/vector results are found, traverse N hops of graph edges and include related thoughts in the response.",
       annotations: {
-        readOnlyHint: true,
+        readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,
@@ -336,7 +336,7 @@ export function createServerWithDb(db: ThoughtDatabase): McpServer {
       title: "Get Thought",
       description: "Fetch the complete content of a single memory by UUID. Use after search_thoughts or list_thoughts returns a summary that you need to read in full — those tools only return summaries and IDs. Returns all fields: content, summary, type, topics, people, project, source, metadata, and timestamps.",
       annotations: {
-        readOnlyHint: true,
+        readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: true,
         openWorldHint: false,

--- a/src/tools/brief-policy.ts
+++ b/src/tools/brief-policy.ts
@@ -38,7 +38,8 @@ export interface BriefPolicyInput {
 }
 
 const ROLES = new Set<BriefRole>(["constraint", "decision", "milestone", "blocker", "preference", "recent"]);
-const LEGACY_TYPES = new Set(["decision", "reference", "insight"]);
+// `preference` remains readable as a legacy alias; new captures store `decision`.
+const LEGACY_TYPES = new Set(["decision", "reference", "insight", "preference"]);
 const ESSENTIAL_ROLES = new Set<BriefRole>(["constraint", "decision", "milestone", "blocker", "preference"]);
 const LANE: Record<BriefRole, number> = { constraint: 0, decision: 1, milestone: 2, blocker: 3, preference: 4, recent: 5 };
 

--- a/src/tools/capture.ts
+++ b/src/tools/capture.ts
@@ -13,10 +13,10 @@ import {
 } from "../db/resolve-project.js";
 import type { ProjectScopeResolution } from "../db/resolve-project.js";
 import type { ProjectReferenceResolution } from "../db/project-identity.js";
-import { canonicalizeTopics } from "../db/topic-canonicalization.js";
 import {
 	findReconciliationCandidates,
 	reconcile,
+	tokenize,
 } from "../db/reconciliation.js";
 import {
   toolSuccess,
@@ -36,6 +36,8 @@ interface SuggestedConnection {
   summary: string | null;
   similarity_reason: string;
 }
+
+const SUGGESTION_LIMIT = 5;
 
 type TrustLevel = "trusted" | "unverified" | "external";
 
@@ -145,22 +147,32 @@ function captureSingle(
 	const effectiveType = args.type === "preference" ? "decision" : args.type;
 	const type = effectiveType ?? "note";
 	const projectIdentifier = resolvedScope?.currentSlug ?? null;
-	const topics = args.topics ? canonicalizeTopics(args.topics) : [];
+	const topics = args.topics ?? [];
+	const contentTokens = tokenize(args.content);
 	const candidates = findReconciliationCandidates(
 		db.db,
 		args.content,
-		type,
-		projectIdentifier,
+		args.summary,
+		resolvedScope?.projectId ?? null,
+		args.project ?? null,
+		contentTokens,
 	);
-	const decision = reconcile(args.content, type, candidates);
+	const decision = reconcile(args.content, type, candidates, contentTokens);
 
 	if (decision.action === "noop") {
 		const existing = getThought(db.db, decision.existingId)!;
-		updateThought(db.db, existing.id, {
-			topics: canonicalizeTopics([...existing.topics, ...topics]),
-			people: [...new Set([...existing.people, ...(args.people ?? [])])],
-		});
+		const mergedTopics = [...new Set([...existing.topics, ...topics])];
+		const mergedPeople = [...new Set([...existing.people, ...(args.people ?? [])])];
 		incrementReinforcement(db.db, existing.id, 1, true);
+		if (
+			mergedTopics.length !== existing.topics.length ||
+			mergedPeople.length !== existing.people.length
+		) {
+			updateThought(db.db, existing.id, {
+				topics: mergedTopics,
+				people: mergedPeople,
+			});
+		}
 		const links = attachRelated(db, existing.id, args.related_to);
 		return {
 			id: existing.id,
@@ -194,11 +206,11 @@ function captureSingle(
 	const links = attachRelated(db, id, [
 		...(args.related_to ?? []),
 		...decision.suggestedEdges.filter(({ autoApply }) => autoApply).map(({ id }) => id),
-	]);
+	], new Set(candidates.map((candidate) => candidate.id)));
 	const byId = new Map(candidates.map((candidate) => [candidate.id, candidate]));
 	const suggested_connections = decision.suggestedEdges
 		.filter(({ autoApply }) => !autoApply)
-		.slice(0, 5)
+		.slice(0, SUGGESTION_LIMIT)
 		.map(({ id: candidateId, similarity }) => ({
 			id: candidateId,
 			summary: byId.get(candidateId)?.summary ?? null,
@@ -212,11 +224,24 @@ function attachRelated(
 	db: ThoughtDatabase,
 	sourceId: string,
 	relatedIds: string[] | undefined,
+	knownExistingIds: ReadonlySet<string> = new Set(),
 ): { linked: string[]; skipped: string[] } {
 	const linked: string[] = [];
 	const skipped: string[] = [];
-	for (const relatedId of new Set(relatedIds ?? [])) {
-		if (relatedId === sourceId || !getThought(db.db, relatedId)) {
+	const uniqueIds = [...new Set(relatedIds ?? [])];
+	const idsToCheck = uniqueIds.filter(
+		(id) => id !== sourceId && !knownExistingIds.has(id),
+	);
+	const existingIds = new Set(knownExistingIds);
+	if (idsToCheck.length > 0) {
+		const placeholders = idsToCheck.map(() => "?").join(", ");
+		const rows = db.db
+			.prepare(`SELECT id FROM thoughts WHERE id IN (${placeholders})`)
+			.all(...idsToCheck) as Array<{ id: string }>;
+		for (const { id } of rows) existingIds.add(id);
+	}
+	for (const relatedId of uniqueIds) {
+		if (relatedId === sourceId || !existingIds.has(relatedId)) {
 			skipped.push(relatedId);
 			continue;
 		}

--- a/src/tools/capture.ts
+++ b/src/tools/capture.ts
@@ -1,7 +1,11 @@
 import type { ThoughtDatabase } from "../db/database.js";
-import { insertThought, getThought } from "../db/thoughts.js";
+import {
+	getThought,
+	incrementReinforcement,
+	insertThought,
+	updateThought,
+} from "../db/thoughts.js";
 import { linkThoughts } from "../db/edges.js";
-import { searchThoughts, sanitizeFTSQuery } from "../db/fts.js";
 import {
 	resolveProjectReference,
 	resolveProjectScope,
@@ -9,6 +13,11 @@ import {
 } from "../db/resolve-project.js";
 import type { ProjectScopeResolution } from "../db/resolve-project.js";
 import type { ProjectReferenceResolution } from "../db/project-identity.js";
+import { canonicalizeTopics } from "../db/topic-canonicalization.js";
+import {
+	findReconciliationCandidates,
+	reconcile,
+} from "../db/reconciliation.js";
 import {
   toolSuccess,
   toolError,
@@ -22,52 +31,10 @@ import {
   MAX_BULK_THOUGHTS,
 } from "./helpers.js";
 
-const SUGGESTION_LIMIT = 5;
-const SUGGESTION_MIN_RANK = 0.5; // BM25 rank threshold (higher = more relevant)
-
 interface SuggestedConnection {
   id: string;
   summary: string | null;
   similarity_reason: string;
-}
-
-/**
- * Run a quick FTS search against existing thoughts to find potential connections.
- * Returns up to SUGGESTION_LIMIT results above the rank threshold, excluding
- * the newly captured thought itself.
- */
-function findSuggestedConnections(
-  db: ThoughtDatabase,
-  content: string,
-  summary: string | undefined,
-  excludeId: string,
-): SuggestedConnection[] {
-  // Build a search query from the summary (preferred, more focused) or first 200 chars of content
-  const searchText = summary ?? content.slice(0, 200);
-  if (!searchText.trim()) return [];
-
-  const sanitized = sanitizeFTSQuery(searchText);
-  if (!sanitized) return [];
-
-  const ftsResult = searchThoughts(db.db, {
-    query: sanitized,
-    limit: SUGGESTION_LIMIT + 1, // +1 to account for possible self-match
-    offset: 0,
-  });
-
-  const suggestions: SuggestedConnection[] = [];
-  for (const r of ftsResult.results) {
-    if (r.id === excludeId) continue;
-    if (r.rank < SUGGESTION_MIN_RANK) continue;
-    suggestions.push({
-      id: r.id,
-      summary: r.summary,
-      similarity_reason: `FTS match (relevance: ${r.rank.toFixed(2)})`,
-    });
-    if (suggestions.length >= SUGGESTION_LIMIT) break;
-  }
-
-  return suggestions;
 }
 
 type TrustLevel = "trusted" | "unverified" | "external";
@@ -165,22 +132,55 @@ function captureSingle(
 		ProjectReferenceResolution,
 		{ kind: "resolved" }
 	> | null,
-): { id: string; linked: string[]; skipped: string[] } {
+): {
+	id: string;
+	action: "noop" | "add";
+	linked: string[];
+	skipped: string[];
+	suggested_connections: SuggestedConnection[];
+} {
   // Default visibility: 'shared' for preference type, otherwise 'personal'
   const effectiveVisibility =
     args.visibility ?? (args.type === "preference" ? "shared" : undefined);
+	const effectiveType = args.type === "preference" ? "decision" : args.type;
+	const type = effectiveType ?? "note";
+	const projectIdentifier = resolvedScope?.currentSlug ?? null;
+	const topics = args.topics ? canonicalizeTopics(args.topics) : [];
+	const candidates = findReconciliationCandidates(
+		db.db,
+		args.content,
+		type,
+		projectIdentifier,
+	);
+	const decision = reconcile(args.content, type, candidates);
+
+	if (decision.action === "noop") {
+		const existing = getThought(db.db, decision.existingId)!;
+		updateThought(db.db, existing.id, {
+			topics: canonicalizeTopics([...existing.topics, ...topics]),
+			people: [...new Set([...existing.people, ...(args.people ?? [])])],
+		});
+		incrementReinforcement(db.db, existing.id, 1, true);
+		const links = attachRelated(db, existing.id, args.related_to);
+		return {
+			id: existing.id,
+			action: "noop",
+			...links,
+			suggested_connections: [],
+		};
+	}
 
   const id = insertThought(db.db, {
     content: args.content,
     summary: args.summary,
-    type: args.type,
+		type,
     source: args.source,
     source_agent: args.source_agent,
     trust_level: args.trust_level,
     project: args.project,
-		project_identifier: resolvedScope?.currentSlug,
+		project_identifier: projectIdentifier ?? undefined,
     visibility: effectiveVisibility,
-    topics: args.topics,
+		topics: topics,
     people: args.people,
     metadata: args.metadata,
   });
@@ -191,30 +191,47 @@ function captureSingle(
 			.run(resolvedScope.projectId, id);
 	}
 
-  const linked: string[] = [];
-  const skipped: string[] = [];
+	const links = attachRelated(db, id, [
+		...(args.related_to ?? []),
+		...decision.suggestedEdges.filter(({ autoApply }) => autoApply).map(({ id }) => id),
+	]);
+	const byId = new Map(candidates.map((candidate) => [candidate.id, candidate]));
+	const suggested_connections = decision.suggestedEdges
+		.filter(({ autoApply }) => !autoApply)
+		.slice(0, 5)
+		.map(({ id: candidateId, similarity }) => ({
+			id: candidateId,
+			summary: byId.get(candidateId)?.summary ?? null,
+			similarity_reason: `Jaccard token similarity: ${similarity.toFixed(2)}`,
+		}));
 
-  if (args.related_to && Array.isArray(args.related_to)) {
-    for (const relatedId of args.related_to) {
-      const exists = getThought(db.db, relatedId);
-      if (!exists) {
-        skipped.push(relatedId);
-        continue;
-      }
-      try {
-        linkThoughts(db, {
-          source_id: id,
-          target_id: relatedId,
-          edge_type: "related",
-        });
-        linked.push(relatedId);
-      } catch {
-        skipped.push(relatedId);
-      }
-    }
-  }
+	return { id, action: "add", ...links, suggested_connections };
+}
 
-  return { id, linked, skipped };
+function attachRelated(
+	db: ThoughtDatabase,
+	sourceId: string,
+	relatedIds: string[] | undefined,
+): { linked: string[]; skipped: string[] } {
+	const linked: string[] = [];
+	const skipped: string[] = [];
+	for (const relatedId of new Set(relatedIds ?? [])) {
+		if (relatedId === sourceId || !getThought(db.db, relatedId)) {
+			skipped.push(relatedId);
+			continue;
+		}
+		try {
+			linkThoughts(db, {
+				source_id: sourceId,
+				target_id: relatedId,
+				edge_type: "related",
+			});
+			linked.push(relatedId);
+		} catch {
+			skipped.push(relatedId);
+		}
+	}
+	return { linked, skipped };
 }
 
 type ResolvedReference = Extract<
@@ -403,17 +420,11 @@ export function handleCaptureThought(
 		);
   })();
 
-  const suggested_connections = findSuggestedConnections(
-    db,
-    a.content,
-    a.summary,
-    result.id,
-  );
-
   return toolSuccess({
     id: result.id,
+		action: result.action,
     linked: result.linked,
     skipped: result.skipped,
-    suggested_connections,
+		suggested_connections: result.suggested_connections,
   });
 }

--- a/src/tools/get.ts
+++ b/src/tools/get.ts
@@ -1,5 +1,5 @@
 import type { ThoughtDatabase } from "../db/database.js";
-import { getThought } from "../db/thoughts.js";
+import { getThought, incrementReinforcement } from "../db/thoughts.js";
 import { toolSuccess, toolError, type ToolResult } from "./helpers.js";
 
 export function handleGetThought(
@@ -16,6 +16,12 @@ export function handleGetThought(
   if (!thought) {
     return toolError("not_found", `Thought "${id}" not found`);
   }
+
+	try {
+		incrementReinforcement(db.db, id, 1, false);
+	} catch {
+		// Reinforcement is best-effort and must never prevent a successful read.
+	}
 
   // Strip embedding buffer from response (binary data isn't useful in JSON)
   const { embedding, ...rest } = thought;

--- a/src/tools/get.ts
+++ b/src/tools/get.ts
@@ -12,13 +12,15 @@ export function handleGetThought(
     return toolError("invalid_input", "id is required and must be a string");
   }
 
-  const thought = getThought(db.db, id);
+	let thought = getThought(db.db, id);
   if (!thought) {
     return toolError("not_found", `Thought "${id}" not found`);
   }
 
 	try {
-		incrementReinforcement(db.db, id, 1, false);
+		if (incrementReinforcement(db.db, id, 1, false)) {
+			thought = getThought(db.db, id) ?? thought;
+		}
 	} catch {
 		// Reinforcement is best-effort and must never prevent a successful read.
 	}

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -4,6 +4,11 @@ import { searchThoughts } from "../db/fts.js";
 import { searchByEmbedding } from "../db/vectors.js";
 import { toolSuccess, toolError, clampLimit, type ToolResult } from "./helpers.js";
 import { resolveReadProjectScope } from "./project-scope.js";
+import { canonicalizeTopic } from "../db/topic-canonicalization.js";
+import {
+	recordSearchTelemetry,
+	type SearchMode,
+} from "../db/search-telemetry.js";
 
 interface SearchArgs {
   query?: string;
@@ -18,6 +23,7 @@ interface SearchArgs {
   shared_only?: boolean;
   all_projects?: boolean;
   graph_depth?: number;
+	topic?: string;
 }
 
 interface SearchMetadata {
@@ -60,6 +66,10 @@ function eligibleVectorThoughtIds(
     whereClauses.push("project = ?");
     params.push(args.project);
   }
+	if (args.topic) {
+		whereClauses.push("topics LIKE ?");
+		params.push(`%"${canonicalizeTopic(args.topic)}"%`);
+	}
   if (args.shared_only) whereClauses.push("visibility = 'shared'");
   if (projectId !== undefined) {
     whereClauses.push(args.include_shared
@@ -75,12 +85,13 @@ function eligibleVectorThoughtIds(
 }
 
 function matchesFilters(
-  item: { id: string; type: string },
+  item: { id: string; type: string; topics: string[] },
   metadata: Map<string, SearchMetadata>,
   args: SearchArgs,
   projectId: string | undefined,
 ): boolean {
   if (args.type && item.type !== args.type) return false;
+	if (args.topic && !item.topics.includes(canonicalizeTopic(args.topic))) return false;
   const meta = metadata.get(item.id);
   if (!meta) return false;
   if (args.project && meta.project !== args.project) return false;
@@ -116,6 +127,23 @@ export function handleSearchThoughts(
   const eligibleThoughtIds = a.embedding
     ? eligibleVectorThoughtIds(db, a, projectId)
     : undefined;
+	const recordTelemetry = (
+		mode: SearchMode,
+		results: Array<{ id: string }>,
+		resultCount: number,
+	): void => {
+		try {
+			recordSearchTelemetry(db.db, {
+				query: a.query ?? "",
+				mode,
+				resultCount,
+				topIds: results.map(({ id }) => id),
+				projectIdentifier: a.all_projects === true ? null : scope.currentSlug ?? null,
+			});
+		} catch {
+			// Telemetry is best-effort and must not affect search availability.
+		}
+	};
 
   if (a.embedding && !a.query) {
     const poolSize = projectId !== undefined || a.type || a.project || a.shared_only ? 100 : limit;
@@ -132,6 +160,7 @@ export function handleSearchThoughts(
       .map((item) => ({ ...item, ...metadata.get(item.id)! }));
     const results = filtered.slice(0, limit);
     const graph_related = fetchGraphRelated(db, results.map((r) => r.id), graphDepth);
+		recordTelemetry("vector", results, filtered.length);
     return toolSuccess({
       mode: "vector",
       results,
@@ -152,8 +181,10 @@ export function handleSearchThoughts(
       project_id: projectId,
       include_shared: a.include_shared,
       shared_only: a.shared_only,
+			topic: a.topic,
     });
     const graph_related = fetchGraphRelated(db, ftsResult.results.map((r) => r.id), graphDepth);
+		recordTelemetry("fts", ftsResult.results, ftsResult.total_count);
     return toolSuccess({
       mode: "fts",
       ...ftsResult,
@@ -172,6 +203,7 @@ export function handleSearchThoughts(
       project_id: projectId,
       include_shared: a.include_shared,
       shared_only: a.shared_only,
+			topic: a.topic,
     });
     const vectorResult = searchByEmbedding(
       db.db,
@@ -212,6 +244,7 @@ export function handleSearchThoughts(
     const total_count = scored.length;
     const sliced = scored.slice(offset, offset + limit);
     const graph_related = fetchGraphRelated(db, sliced.map((r) => r.id), graphDepth);
+		recordTelemetry("hybrid", sliced, total_count);
     return toolSuccess({
       mode: "hybrid",
       results: sliced,

--- a/src/tools/search.ts
+++ b/src/tools/search.ts
@@ -4,7 +4,10 @@ import { searchThoughts } from "../db/fts.js";
 import { searchByEmbedding } from "../db/vectors.js";
 import { toolSuccess, toolError, clampLimit, type ToolResult } from "./helpers.js";
 import { resolveReadProjectScope } from "./project-scope.js";
-import { canonicalizeTopic } from "../db/topic-canonicalization.js";
+import {
+	canonicalizeTopic,
+	topicLikePattern,
+} from "../db/topic-canonicalization.js";
 import {
 	recordSearchTelemetry,
 	type SearchMode,
@@ -68,7 +71,7 @@ function eligibleVectorThoughtIds(
   }
 	if (args.topic) {
 		whereClauses.push("topics LIKE ?");
-		params.push(`%"${canonicalizeTopic(args.topic)}"%`);
+		params.push(topicLikePattern(args.topic));
 	}
   if (args.shared_only) whereClauses.push("visibility = 'shared'");
   if (projectId !== undefined) {
@@ -89,9 +92,10 @@ function matchesFilters(
   metadata: Map<string, SearchMetadata>,
   args: SearchArgs,
   projectId: string | undefined,
+	canonicalTopic: string | undefined,
 ): boolean {
   if (args.type && item.type !== args.type) return false;
-	if (args.topic && !item.topics.includes(canonicalizeTopic(args.topic))) return false;
+	if (canonicalTopic && !item.topics.includes(canonicalTopic)) return false;
   const meta = metadata.get(item.id);
   if (!meta) return false;
   if (args.project && meta.project !== args.project) return false;
@@ -124,6 +128,7 @@ export function handleSearchThoughts(
   const limit = clampLimit(a.limit);
   const offset = a.offset ?? 0;
   const graphDepth = Math.min(Math.max(a.graph_depth ?? 0, 0), 5);
+	const canonicalTopic = a.topic ? canonicalizeTopic(a.topic) : undefined;
   const eligibleThoughtIds = a.embedding
     ? eligibleVectorThoughtIds(db, a, projectId)
     : undefined;
@@ -156,7 +161,7 @@ export function handleSearchThoughts(
     );
     const metadata = loadSearchMetadata(db, candidates.map((item) => item.id));
     const filtered = candidates
-      .filter((item) => matchesFilters(item, metadata, a, projectId))
+      .filter((item) => matchesFilters(item, metadata, a, projectId, canonicalTopic))
       .map((item) => ({ ...item, ...metadata.get(item.id)! }));
     const results = filtered.slice(0, limit);
     const graph_related = fetchGraphRelated(db, results.map((r) => r.id), graphDepth);
@@ -220,7 +225,7 @@ export function handleSearchThoughts(
     const metadata = loadSearchMetadata(db, [...resultById.keys()]);
     const K = 60;
     const scored = [...resultById.values()]
-      .filter((item) => matchesFilters(item, metadata, a, projectId))
+      .filter((item) => matchesFilters(item, metadata, a, projectId, canonicalTopic))
       .map((item) => {
         const ftsRank = ftsRanks.get(item.id);
         const vectorRank = vectorRanks.get(item.id);

--- a/src/tools/update.ts
+++ b/src/tools/update.ts
@@ -120,7 +120,7 @@ export function handleUpdateThought(
   const updates: Record<string, unknown> = {};
   if (a.content !== undefined) updates.content = a.content;
   if (a.summary !== undefined) updates.summary = a.summary;
-  if (a.type !== undefined) updates.type = a.type;
+  if (a.type !== undefined) updates.type = a.type === "preference" ? "decision" : a.type;
   if (a.source !== undefined) updates.source = a.source;
   if (a.project !== undefined) updates.project = a.project;
   if (projectReference?.kind === "resolved") {

--- a/tests/db/database.test.ts
+++ b/tests/db/database.test.ts
@@ -28,7 +28,7 @@ describe("ThoughtDatabase", () => {
 
   it("runs migrations to latest version", () => {
     db = new ThoughtDatabase(":memory:");
-		expect(db.getSchemaVersion()).toBe(10);
+		expect(db.getSchemaVersion()).toBe(11);
   });
 
   it("creates thoughts table", () => {
@@ -65,7 +65,7 @@ describe("ThoughtDatabase", () => {
     db = new ThoughtDatabase(":memory:");
     // Simulate re-running migrations on same version
     const version = db.getSchemaVersion();
-		expect(version).toBe(10);
+		expect(version).toBe(11);
   });
 
   it("creates oauth_clients table after migration", () => {

--- a/tests/db/database.test.ts
+++ b/tests/db/database.test.ts
@@ -28,7 +28,7 @@ describe("ThoughtDatabase", () => {
 
   it("runs migrations to latest version", () => {
     db = new ThoughtDatabase(":memory:");
-		expect(db.getSchemaVersion()).toBe(8);
+		expect(db.getSchemaVersion()).toBe(10);
   });
 
   it("creates thoughts table", () => {
@@ -65,7 +65,7 @@ describe("ThoughtDatabase", () => {
     db = new ThoughtDatabase(":memory:");
     // Simulate re-running migrations on same version
     const version = db.getSchemaVersion();
-		expect(version).toBe(8);
+		expect(version).toBe(10);
   });
 
   it("creates oauth_clients table after migration", () => {

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { ThoughtDatabase } from "../../src/db/database.js";
 import { deriveExistingProjectId } from "../../src/db/project-identity.js";
 import {
+	CURRENT_SCHEMA_VERSION,
 	getMigrations,
 	getSchemaVersion,
 	runMigrations,
@@ -23,8 +24,9 @@ describe("Migration v5 — version-stamp alignment with Shelby-MacOS", () => {
     db?.close();
   });
 
-	it("schema version is 10 after all migrations", () => {
-		expect(getSchemaVersion(db.db)).toBe(10);
+	it("schema version is 11 after all migrations", () => {
+		expect(getSchemaVersion(db.db)).toBe(11);
+		expect(CURRENT_SCHEMA_VERSION).toBe(11);
   });
 
   it("thoughts table has source_agent column", () => {
@@ -126,7 +128,7 @@ describe("migration v6 — project identity", () => {
     const db = new Database(":memory:");
     runMigrations(db);
 
-		expect(getSchemaVersion(db)).toBe(10);
+		expect(getSchemaVersion(db)).toBe(11);
 
 		const thoughtCols = db
 			.prepare("PRAGMA table_info(thoughts)")
@@ -151,7 +153,7 @@ describe("migration v6 — project identity", () => {
   });
 });
 
-describe("migration v9 — thought confirmation timestamp", () => {
+describe("migration v11 — thought confirmation timestamp", () => {
 	it("adds nullable last_confirmed_at without backfilling existing thoughts", () => {
 		const db = new Database(":memory:");
 		for (const migration of getMigrations().filter(({ version }) => version <= 8)) {
@@ -163,10 +165,12 @@ describe("migration v9 — thought confirmation timestamp", () => {
 			 VALUES ('legacy', 'content', 'note', 'test', '2026-08-14T00:00:00Z', '2026-08-14T00:00:00Z')`,
 		).run();
 
-		getMigrations().find(({ version }) => version === 9)!.up(db);
-		setSchemaVersion(db, 9);
+		for (const migration of getMigrations().filter(({ version }) => version >= 9)) {
+			migration.up(db);
+			setSchemaVersion(db, migration.version);
+		}
 
-		expect(getSchemaVersion(db)).toBe(9);
+		expect(getSchemaVersion(db)).toBe(11);
 		expect(
 			db.prepare("SELECT last_confirmed_at FROM thoughts WHERE id = 'legacy'").get(),
 		).toEqual({ last_confirmed_at: null });
@@ -395,7 +399,7 @@ describe("migration v8 — canonical project identity", () => {
 				)
 				.get();
 			expect(after).toEqual(before);
-			expect(reopened.getSchemaVersion()).toBe(10);
+			expect(reopened.getSchemaVersion()).toBe(11);
 			reopened.close();
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
@@ -403,23 +407,70 @@ describe("migration v8 — canonical project identity", () => {
   });
 });
 
-describe("migration v10 — local search telemetry", () => {
-	it("creates the search_telemetry table with the parity columns", () => {
+describe("migrations v9-v11 — macOS parity", () => {
+	it("creates the exact search telemetry and feedback schemas", () => {
 		const db = new Database(":memory:");
 		runMigrations(db);
 
-		const columns = db.prepare("PRAGMA table_info(search_telemetry)").all() as Array<{ name: string }>;
-		expect(columns.map(({ name }) => name)).toEqual([
-			"id",
-			"created_at",
-			"query_hash",
-			"mode",
-			"result_count",
-			"top_ids",
-			"rediscovery",
-			"project_identifier",
+		const telemetryColumns = db.prepare("PRAGMA table_info(search_telemetry)").all() as Array<{
+			name: string;
+			notnull: number;
+			dflt_value: string | null;
+		}>;
+		expect(telemetryColumns.map(({ name, notnull, dflt_value }) => ({ name, notnull, dflt_value }))).toEqual([
+			{ name: "id", notnull: 0, dflt_value: null },
+			{ name: "created_at", notnull: 1, dflt_value: null },
+			{ name: "query_hash", notnull: 0, dflt_value: null },
+			{ name: "mode", notnull: 0, dflt_value: null },
+			{ name: "result_count", notnull: 1, dflt_value: "0" },
+			{ name: "top_ids", notnull: 0, dflt_value: null },
+			{ name: "rediscovery", notnull: 1, dflt_value: "0" },
+			{ name: "project_identifier", notnull: 0, dflt_value: null },
 		]);
-		expect(getSchemaVersion(db)).toBe(10);
+		expect(db.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_search_telemetry_created'").get()).toEqual({ name: "idx_search_telemetry_created" });
+		expect(db.prepare("PRAGMA table_info(feedback)").all()).toEqual(expect.arrayContaining([
+			expect.objectContaining({ name: "id", notnull: 0 }),
+			expect.objectContaining({ name: "created_at", notnull: 1 }),
+			expect.objectContaining({ name: "feature", notnull: 1 }),
+			expect.objectContaining({ name: "variant_id", notnull: 0 }),
+			expect.objectContaining({ name: "label", notnull: 1 }),
+			expect.objectContaining({ name: "prompt_hash", notnull: 0 }),
+			expect.objectContaining({ name: "response_hash", notnull: 0 }),
+		]));
+		expect(db.prepare("SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_feedback_variant'").get()).toEqual({ name: "idx_feedback_variant" });
+		expect(getSchemaVersion(db)).toBe(11);
+		db.close();
+	});
+
+	it.each([9, 10])("walks a macOS-stamped v%i database to v11", (macVersion) => {
+		const db = new Database(":memory:");
+		for (const migration of getMigrations().filter(({ version }) => version <= 8)) migration.up(db);
+		db.exec(`
+			CREATE TABLE IF NOT EXISTS search_telemetry (
+				id TEXT PRIMARY KEY, created_at TEXT NOT NULL, query_hash TEXT, mode TEXT,
+				result_count INTEGER NOT NULL DEFAULT 0, top_ids TEXT,
+				rediscovery INTEGER NOT NULL DEFAULT 0, project_identifier TEXT
+			);
+			CREATE INDEX IF NOT EXISTS idx_search_telemetry_created ON search_telemetry(created_at);
+		`);
+		if (macVersion >= 10) {
+			db.exec(`
+				CREATE TABLE IF NOT EXISTS feedback (
+					id TEXT PRIMARY KEY, created_at TEXT NOT NULL, feature TEXT NOT NULL,
+					variant_id TEXT, label TEXT NOT NULL, prompt_hash TEXT, response_hash TEXT
+				);
+				CREATE INDEX IF NOT EXISTS idx_feedback_variant ON feedback(variant_id);
+			`);
+		}
+		setSchemaVersion(db, macVersion);
+
+		runMigrations(db);
+
+		expect(getSchemaVersion(db)).toBe(11);
+		expect(db.prepare("PRAGMA table_info(feedback)").all()).not.toHaveLength(0);
+		expect(db.prepare("PRAGMA table_info(thoughts)").all()).toEqual(expect.arrayContaining([
+			expect.objectContaining({ name: "last_confirmed_at" }),
+		]));
 		db.close();
 	});
 });

--- a/tests/db/migrations.test.ts
+++ b/tests/db/migrations.test.ts
@@ -23,8 +23,8 @@ describe("Migration v5 — version-stamp alignment with Shelby-MacOS", () => {
     db?.close();
   });
 
-	it("schema version is 8 after all migrations", () => {
-		expect(getSchemaVersion(db.db)).toBe(8);
+	it("schema version is 10 after all migrations", () => {
+		expect(getSchemaVersion(db.db)).toBe(10);
   });
 
   it("thoughts table has source_agent column", () => {
@@ -126,7 +126,7 @@ describe("migration v6 — project identity", () => {
     const db = new Database(":memory:");
     runMigrations(db);
 
-		expect(getSchemaVersion(db)).toBe(8);
+		expect(getSchemaVersion(db)).toBe(10);
 
 		const thoughtCols = db
 			.prepare("PRAGMA table_info(thoughts)")
@@ -149,6 +149,29 @@ describe("migration v6 — project identity", () => {
     );
     db.close();
   });
+});
+
+describe("migration v9 — thought confirmation timestamp", () => {
+	it("adds nullable last_confirmed_at without backfilling existing thoughts", () => {
+		const db = new Database(":memory:");
+		for (const migration of getMigrations().filter(({ version }) => version <= 8)) {
+			migration.up(db);
+		}
+		setSchemaVersion(db, 8);
+		db.prepare(
+			`INSERT INTO thoughts (id, content, type, source, created_at, updated_at)
+			 VALUES ('legacy', 'content', 'note', 'test', '2026-08-14T00:00:00Z', '2026-08-14T00:00:00Z')`,
+		).run();
+
+		getMigrations().find(({ version }) => version === 9)!.up(db);
+		setSchemaVersion(db, 9);
+
+		expect(getSchemaVersion(db)).toBe(9);
+		expect(
+			db.prepare("SELECT last_confirmed_at FROM thoughts WHERE id = 'legacy'").get(),
+		).toEqual({ last_confirmed_at: null });
+		db.close();
+	});
 });
 
 describe("migration v7 — normalize legacy display-name project_identifiers", () => {
@@ -372,10 +395,31 @@ describe("migration v8 — canonical project identity", () => {
 				)
 				.get();
 			expect(after).toEqual(before);
-			expect(reopened.getSchemaVersion()).toBe(8);
+			expect(reopened.getSchemaVersion()).toBe(10);
 			reopened.close();
 		} finally {
 			rmSync(directory, { recursive: true, force: true });
 		}
   });
+});
+
+describe("migration v10 — local search telemetry", () => {
+	it("creates the search_telemetry table with the parity columns", () => {
+		const db = new Database(":memory:");
+		runMigrations(db);
+
+		const columns = db.prepare("PRAGMA table_info(search_telemetry)").all() as Array<{ name: string }>;
+		expect(columns.map(({ name }) => name)).toEqual([
+			"id",
+			"created_at",
+			"query_hash",
+			"mode",
+			"result_count",
+			"top_ids",
+			"rediscovery",
+			"project_identifier",
+		]);
+		expect(getSchemaVersion(db)).toBe(10);
+		db.close();
+	});
 });

--- a/tests/db/reconciliation.test.ts
+++ b/tests/db/reconciliation.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { reconcile } from "../../src/db/reconciliation.js";
+
+describe("reconcile", () => {
+	it("applies the 0.9 noop, 0.8 edge, and 0.3 suggestion thresholds", () => {
+		const candidates = [
+			{ id: "noop", content: "alpha bravo charlie delta echo" },
+			{ id: "edge", content: "alpha bravo charlie delta foxtrot" },
+			{ id: "suggest", content: "alpha bravo charlie golf" },
+		];
+
+		expect(reconcile("alpha bravo charlie delta echo", "note", candidates)).toEqual({
+			action: "noop",
+			existingId: "noop",
+			suggestedEdges: [],
+		});
+		expect(reconcile("alpha bravo charlie delta", "note", candidates.slice(1))).toEqual({
+			action: "add",
+			suggestedEdges: [
+				{ id: "edge", similarity: 0.8, autoApply: true },
+				{ id: "suggest", similarity: 0.6, autoApply: false },
+			],
+		});
+	});
+
+	it("does not reconcile inputs or candidates with fewer than four tokens", () => {
+		expect(reconcile("alpha bravo charlie", "note", [
+			{ id: "short", content: "alpha bravo charlie" },
+		])).toEqual({ action: "add", suggestedEdges: [] });
+	});
+});

--- a/tests/db/reconciliation.test.ts
+++ b/tests/db/reconciliation.test.ts
@@ -4,9 +4,9 @@ import { reconcile } from "../../src/db/reconciliation.js";
 describe("reconcile", () => {
 	it("applies the 0.9 noop, 0.8 edge, and 0.3 suggestion thresholds", () => {
 		const candidates = [
-			{ id: "noop", content: "alpha bravo charlie delta echo" },
-			{ id: "edge", content: "alpha bravo charlie delta foxtrot" },
-			{ id: "suggest", content: "alpha bravo charlie golf" },
+			{ id: "noop", content: "alpha bravo charlie delta echo", type: "note" },
+			{ id: "edge", content: "alpha bravo charlie delta foxtrot", type: "note" },
+			{ id: "suggest", content: "alpha bravo charlie golf", type: "note" },
 		];
 
 		expect(reconcile("alpha bravo charlie delta echo", "note", candidates)).toEqual({
@@ -25,7 +25,18 @@ describe("reconcile", () => {
 
 	it("does not reconcile inputs or candidates with fewer than four tokens", () => {
 		expect(reconcile("alpha bravo charlie", "note", [
-			{ id: "short", content: "alpha bravo charlie" },
+			{ id: "short", content: "alpha bravo charlie", type: "note" },
 		])).toEqual({ action: "add", suggestedEdges: [] });
+	});
+
+	it("suggests an edge for a cross-type match without treating it as a NOOP", () => {
+		expect(reconcile("alpha bravo charlie delta", "note", [
+			{ id: "decision", content: "alpha bravo charlie delta", type: "decision" },
+		])).toEqual({
+			action: "add",
+			suggestedEdges: [
+				{ id: "decision", similarity: 1, autoApply: true },
+			],
+		});
 	});
 });

--- a/tests/db/search-telemetry.test.ts
+++ b/tests/db/search-telemetry.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { isRediscovery } from "../../src/db/search-telemetry.js";
+
+describe("isRediscovery", () => {
+	it("requires more than half of the prior top ids to overlap", () => {
+		expect(isRediscovery(["a", "b", "c"], ["a", "b", "x"])).toBe(true);
+		expect(isRediscovery(["a", "b"], ["a", "x"])).toBe(false);
+		expect(isRediscovery([], [])).toBe(false);
+	});
+});

--- a/tests/db/thoughts.test.ts
+++ b/tests/db/thoughts.test.ts
@@ -75,6 +75,15 @@ describe("thoughts CRUD", () => {
       expect(thought.visibility).toBe("team");
       expect(thought.metadata).toEqual({ priority: "high", version: 2 });
     });
+
+		it("canonicalizes topics at the database insert boundary", () => {
+			const id = insertThought(db, {
+				content: "Canonical insert",
+				topics: [" Knowledge Graph ", "knowledge_graph", "API  Design"],
+			});
+
+			expect(getThought(db, id)?.topics).toEqual(["knowledge-graph", "api-design"]);
+		});
   });
 
   describe("getThought", () => {
@@ -87,11 +96,13 @@ describe("thoughts CRUD", () => {
 	describe("incrementReinforcement", () => {
 		it("increments use count without confirming by default", () => {
 			const id = insertThought(db, { content: "Useful thought" });
+			db.prepare("UPDATE thoughts SET updated_at = '2000-01-01T00:00:00.000Z' WHERE id = ?").run(id);
 
 			expect(incrementReinforcement(db, id, 2)).toBe(true);
 
 			const thought = getThought(db, id)!;
 			expect(thought.reinforcement_count).toBe(2);
+			expect(thought.updated_at).not.toBe("2000-01-01T00:00:00.000Z");
 			expect(thought.last_confirmed_at).toBeNull();
 		});
 
@@ -139,6 +150,16 @@ describe("thoughts CRUD", () => {
       const thought = getThought(db, id)!;
       expect(thought.topics).toEqual(["new", "topics"]);
     });
+
+		it("canonicalizes topics at the database update boundary", () => {
+			const id = insertThought(db, { content: "Test", topics: ["old"] });
+
+			updateThought(db, id, {
+				topics: [" Knowledge Graph ", "knowledge_graph", "API  Design"],
+			});
+
+			expect(getThought(db, id)?.topics).toEqual(["knowledge-graph", "api-design"]);
+		});
 
     it("updates updated_at timestamp", () => {
       const id = insertThought(db, { content: "Test" });

--- a/tests/db/thoughts.test.ts
+++ b/tests/db/thoughts.test.ts
@@ -7,6 +7,7 @@ import {
   deleteThought,
   listThoughts,
   countThoughts,
+	incrementReinforcement,
 } from "../../src/db/thoughts.js";
 import { runMigrations } from "../../src/db/migrations.js";
 import BetterSqlite3 from "better-sqlite3";
@@ -46,6 +47,7 @@ describe("thoughts CRUD", () => {
       expect(thought!.embedding).toBeNull();
       expect(thought!.consolidated_into).toBeNull();
       expect(thought!.reinforcement_count).toBe(0);
+		expect(thought!.last_confirmed_at).toBeNull();
       expect(thought!.created_at).toBeTruthy();
       expect(thought!.updated_at).toBeTruthy();
     });
@@ -81,6 +83,28 @@ describe("thoughts CRUD", () => {
       expect(result).toBeNull();
     });
   });
+
+	describe("incrementReinforcement", () => {
+		it("increments use count without confirming by default", () => {
+			const id = insertThought(db, { content: "Useful thought" });
+
+			expect(incrementReinforcement(db, id, 2)).toBe(true);
+
+			const thought = getThought(db, id)!;
+			expect(thought.reinforcement_count).toBe(2);
+			expect(thought.last_confirmed_at).toBeNull();
+		});
+
+		it("sets last_confirmed_at when explicitly confirming", () => {
+			const id = insertThought(db, { content: "Confirmed thought" });
+
+			expect(incrementReinforcement(db, id, 1, true)).toBe(true);
+
+			const thought = getThought(db, id)!;
+			expect(thought.reinforcement_count).toBe(1);
+			expect(thought.last_confirmed_at).toBeTruthy();
+		});
+	});
 
   describe("updateThought", () => {
     it("updates content", () => {

--- a/tests/db/topic-canonicalization.test.ts
+++ b/tests/db/topic-canonicalization.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+	canonicalizeTopic,
+	canonicalizeTopics,
+} from "../../src/db/topic-canonicalization.js";
+
+describe("topic canonicalization", () => {
+	it.each([
+		[" Knowledge Graph ", "knowledge-graph"],
+		["knowledge_graph", "knowledge-graph"],
+		["knowledge---  __graph", "knowledge-graph"],
+	])("canonicalizes %j to %j", (input, expected) => {
+		expect(canonicalizeTopic(input)).toBe(expected);
+	});
+
+	it("deduplicates in first-seen order and removes empty topics", () => {
+		expect(canonicalizeTopics([
+			" Knowledge Graph ",
+			"API Design",
+			"knowledge_graph",
+			"  ",
+		])).toEqual(["knowledge-graph", "api-design"]);
+	});
+});

--- a/tests/mcp/integration.test.ts
+++ b/tests/mcp/integration.test.ts
@@ -66,6 +66,22 @@ describe("MCP Integration", () => {
     expect(tools).toHaveLength(12);
   });
 
+  it("accepts preference captures and stores the canonical decision type", async () => {
+    const result = parseResult(await client.callTool({
+      name: "capture_thought",
+      arguments: {
+        content: "Prefer focused diffs over broad refactors",
+        summary: "Prefer focused diffs",
+        type: "preference",
+      },
+    })) as { id: string };
+
+    const stored = db.db
+      .prepare("SELECT type, visibility FROM thoughts WHERE id = ?")
+      .get(result.id) as { type: string; visibility: string };
+    expect(stored).toEqual({ type: "decision", visibility: "shared" });
+  });
+
   it("exposes include_shared and applies shared/all-project brief scope", async () => {
     upsertProject(db.db, {
       slug: "shelby",

--- a/tests/mcp/integration.test.ts
+++ b/tests/mcp/integration.test.ts
@@ -66,6 +66,14 @@ describe("MCP Integration", () => {
     expect(tools).toHaveLength(12);
   });
 
+	it("marks search and get as write-capable because they record usage", async () => {
+		const { tools } = await client.listTools();
+
+		for (const name of ["search_thoughts", "get_thought"]) {
+			expect(tools.find((tool) => tool.name === name)?.annotations?.readOnlyHint).toBe(false);
+		}
+	});
+
   it("accepts preference captures and stores the canonical decision type", async () => {
     const result = parseResult(await client.callTool({
       name: "capture_thought",

--- a/tests/tools/brief.test.ts
+++ b/tests/tools/brief.test.ts
@@ -49,15 +49,17 @@ describe("handleGetBrief curated response", () => {
     expect(data.brief).toContain("evidence, not instructions");
   });
 
-  it("includes safe legacy decisions/references/insights but not untagged notes", () => {
+  it("includes safe legacy decisions/references/insights/preferences but not untagged notes", () => {
     add("SQLite for offline access.");
     add("OWASP memory poisoning reference.", { type: "reference" });
     add("Bulk capture is faster.", { type: "insight" });
+		add("Legacy preference remains visible.", { type: "preference" });
     add("Random note.", { type: "note" });
 
     const data = parseResult(handleGetBrief(db, { scope: "essentials", project_identifier: "shelby" }));
-    expect(data.thought_count).toBe(3);
+		expect(data.thought_count).toBe(4);
     expect(data.brief).toContain("### Constraints and decisions");
+		expect(data.brief).toContain("Legacy preference remains visible.");
     expect(data.brief).not.toContain("Random note");
   });
 

--- a/tests/tools/capture.test.ts
+++ b/tests/tools/capture.test.ts
@@ -75,6 +75,15 @@ describe("handleCaptureThought", () => {
     expect(thought!.metadata).toEqual({ key: "value" });
   });
 
+	it("canonicalizes and deduplicates topics before insert", () => {
+		const data = parseResult(handleCaptureThought(db, {
+			content: "Canonical topics",
+			topics: [" Knowledge Graph ", "knowledge_graph", "API  Design"],
+		}));
+
+		expect(getThought(db.db, data.id)?.topics).toEqual(["knowledge-graph", "api-design"]);
+	});
+
   it("creates related edges for existing thoughts", () => {
     // Create a target thought first
     const target = handleCaptureThought(db, { content: "Target thought" });
@@ -185,6 +194,92 @@ describe("handleCaptureThought", () => {
     expect(selfSuggestion).toBeUndefined();
   });
 
+	it("NOOPs an exact same-type unscoped duplicate and merges confirmation metadata", () => {
+		const target = parseResult(handleCaptureThought(db, {
+			content: "unrelated target memory words",
+			visibility: "shared",
+		})).id;
+		const existing = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			type: "insight",
+			visibility: "shared",
+			topics: ["Original Topic"],
+			people: ["Alice"],
+		})).id;
+
+		const data = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			type: "insight",
+			visibility: "shared",
+			topics: ["New Topic"],
+			people: ["Bob"],
+			related_to: [target],
+		}));
+
+		expect(data).toMatchObject({ id: existing, action: "noop", linked: [target] });
+		expect(db.db.prepare("SELECT COUNT(*) AS count FROM thoughts").get()).toEqual({ count: 2 });
+		expect(getThought(db.db, existing)).toMatchObject({
+			topics: ["original-topic", "new-topic"],
+			people: ["Alice", "Bob"],
+			reinforcement_count: 1,
+		});
+		expect(getThought(db.db, existing)?.last_confirmed_at).toBeTruthy();
+		expect(getEdgesBetween(db, existing, target)).toHaveLength(1);
+	});
+
+	it("auto-links at 0.8 and suggests matches from 0.3", () => {
+		const autoTarget = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta",
+			visibility: "shared",
+		})).id;
+		const auto = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			visibility: "shared",
+		}));
+		expect(auto.action).toBe("add");
+		expect(auto.linked).toContain(autoTarget);
+		expect(getEdgesBetween(db, auto.id, autoTarget)).toHaveLength(1);
+
+		const suggestionTarget = parseResult(handleCaptureThought(db, {
+			content: "kilo lima mike november",
+			visibility: "shared",
+		})).id;
+		const suggested = parseResult(handleCaptureThought(db, {
+			content: "kilo lima oscar papa",
+			visibility: "shared",
+		}));
+		expect(suggested.action).toBe("add");
+		expect(getEdgesBetween(db, suggested.id, suggestionTarget)).toHaveLength(0);
+		expect(suggested.suggested_connections).toEqual([
+			expect.objectContaining({ id: suggestionTarget }),
+		]);
+	});
+
+	it("never reconciles across thought type or project slug", () => {
+		upsertProject(db.db, { slug: "alpha-project", displayName: "Alpha", memberRepos: [], memberPaths: [], provisional: false });
+		upsertProject(db.db, { slug: "beta-project", displayName: "Beta", memberRepos: [], memberPaths: [], provisional: false });
+		const content = "same exact content across strict scopes";
+		const first = parseResult(handleCaptureThought(db, {
+			content,
+			type: "note",
+			project_identifier: "alpha-project",
+		})).id;
+		const differentType = parseResult(handleCaptureThought(db, {
+			content,
+			type: "decision",
+			project_identifier: "alpha-project",
+		}));
+		const differentProject = parseResult(handleCaptureThought(db, {
+			content,
+			type: "note",
+			project_identifier: "beta-project",
+		}));
+
+		expect(differentType).toMatchObject({ action: "add" });
+		expect(differentProject).toMatchObject({ action: "add" });
+		expect(new Set([first, differentType.id, differentProject.id]).size).toBe(3);
+	});
+
   it("stamps project_identifier from cwd when not provided explicitly", () => {
     const root = makeGitRepo("git@github.com:acme/My-Project.git");
     try {
@@ -208,6 +303,7 @@ describe("handleCaptureThought", () => {
     const data = parseResult(result);
     const thought = getThought(db.db, data.id);
     expect(thought!.visibility).toBe("shared");
+		expect(thought!.type).toBe("decision");
   });
 
   it("defaults visibility to 'personal' for note type when not specified", () => {

--- a/tests/tools/capture.test.ts
+++ b/tests/tools/capture.test.ts
@@ -194,33 +194,42 @@ describe("handleCaptureThought", () => {
     expect(selfSuggestion).toBeUndefined();
   });
 
-	it("NOOPs an exact same-type unscoped duplicate and merges confirmation metadata", () => {
+	it("NOOPs an exact same-type scoped duplicate and merges confirmation metadata", () => {
+		upsertProject(db.db, { slug: "noop-project", displayName: "NOOP", memberRepos: [], memberPaths: [], provisional: false });
 		const target = parseResult(handleCaptureThought(db, {
 			content: "unrelated target memory words",
-			visibility: "shared",
+			project_identifier: "noop-project",
 		})).id;
 		const existing = parseResult(handleCaptureThought(db, {
 			content: "alpha bravo charlie delta echo",
 			type: "insight",
-			visibility: "shared",
+			project_identifier: "noop-project",
 			topics: ["Original Topic"],
 			people: ["Alice"],
+			trust_level: "unverified",
+			metadata: { original: true },
 		})).id;
 
 		const data = parseResult(handleCaptureThought(db, {
 			content: "alpha bravo charlie delta echo",
+			summary: "alpha bravo charlie delta",
 			type: "insight",
-			visibility: "shared",
+			project_identifier: "noop-project",
 			topics: ["New Topic"],
 			people: ["Bob"],
+			trust_level: "trusted",
+			metadata: { incoming: true },
 			related_to: [target],
 		}));
 
 		expect(data).toMatchObject({ id: existing, action: "noop", linked: [target] });
 		expect(db.db.prepare("SELECT COUNT(*) AS count FROM thoughts").get()).toEqual({ count: 2 });
-		expect(getThought(db.db, existing)).toMatchObject({
+			expect(getThought(db.db, existing)).toMatchObject({
+			summary: null,
 			topics: ["original-topic", "new-topic"],
 			people: ["Alice", "Bob"],
+			trust_level: "unverified",
+			metadata: { original: true },
 			reinforcement_count: 1,
 		});
 		expect(getThought(db.db, existing)?.last_confirmed_at).toBeTruthy();
@@ -228,25 +237,26 @@ describe("handleCaptureThought", () => {
 	});
 
 	it("auto-links at 0.8 and suggests matches from 0.3", () => {
+		upsertProject(db.db, { slug: "edge-project", displayName: "Edges", memberRepos: [], memberPaths: [], provisional: false });
 		const autoTarget = parseResult(handleCaptureThought(db, {
-			content: "alpha bravo charlie delta",
-			visibility: "shared",
+			content: "alpha bravo charlie delta echo",
+			project_identifier: "edge-project",
 		})).id;
 		const auto = parseResult(handleCaptureThought(db, {
-			content: "alpha bravo charlie delta echo",
-			visibility: "shared",
+			content: "alpha bravo charlie delta",
+			project_identifier: "edge-project",
 		}));
 		expect(auto.action).toBe("add");
 		expect(auto.linked).toContain(autoTarget);
 		expect(getEdgesBetween(db, auto.id, autoTarget)).toHaveLength(1);
 
 		const suggestionTarget = parseResult(handleCaptureThought(db, {
-			content: "kilo lima mike november",
-			visibility: "shared",
+			content: "kilo lima mike november oscar papa quebec romeo",
+			project_identifier: "edge-project",
 		})).id;
 		const suggested = parseResult(handleCaptureThought(db, {
-			content: "kilo lima oscar papa",
-			visibility: "shared",
+			content: "kilo lima mike november",
+			project_identifier: "edge-project",
 		}));
 		expect(suggested.action).toBe("add");
 		expect(getEdgesBetween(db, suggested.id, suggestionTarget)).toHaveLength(0);
@@ -255,7 +265,7 @@ describe("handleCaptureThought", () => {
 		]);
 	});
 
-	it("never reconciles across thought type or project slug", () => {
+	it("suggests cross-type edges but never NOOPs across type or project identity", () => {
 		upsertProject(db.db, { slug: "alpha-project", displayName: "Alpha", memberRepos: [], memberPaths: [], provisional: false });
 		upsertProject(db.db, { slug: "beta-project", displayName: "Beta", memberRepos: [], memberPaths: [], provisional: false });
 		const content = "same exact content across strict scopes";
@@ -276,8 +286,66 @@ describe("handleCaptureThought", () => {
 		}));
 
 		expect(differentType).toMatchObject({ action: "add" });
+		expect(differentType.linked).toContain(first);
 		expect(differentProject).toMatchObject({ action: "add" });
+		expect(differentProject.linked).not.toContain(first);
 		expect(new Set([first, differentType.id, differentProject.id]).size).toBe(3);
+	});
+
+	it("uses a non-empty summary as the FTS candidate query", () => {
+		upsertProject(db.db, { slug: "summary-project", displayName: "Summary", memberRepos: [], memberPaths: [], provisional: false });
+		const first = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			project_identifier: "summary-project",
+		})).id;
+
+		const second = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			summary: "unrelated summary query",
+			project_identifier: "summary-project",
+		}));
+
+		expect(second).toMatchObject({ action: "add" });
+		expect(second.id).not.toBe(first);
+	});
+
+	it("reconciles through project_id after the current slug changes", () => {
+		upsertProject(db.db, { slug: "original-slug", displayName: "Renamed", memberRepos: [], memberPaths: [], provisional: false });
+		const first = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			project_identifier: "original-slug",
+		})).id;
+		const projectId = getProjectByAlias(db.db, "original-slug")!.projectId;
+		db.db.prepare("UPDATE projects SET current_slug = 'current-slug' WHERE project_id = ?").run(projectId);
+
+		const duplicate = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			project_identifier: "original-slug",
+		}));
+
+		expect(duplicate).toMatchObject({ id: first, action: "noop" });
+	});
+
+	it("skips the NOOP metadata update when topics and people add nothing", () => {
+		upsertProject(db.db, { slug: "stable-noop", displayName: "Stable", memberRepos: [], memberPaths: [], provisional: false });
+		const first = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			project_identifier: "stable-noop",
+			topics: ["stable-topic"],
+			people: ["Alice"],
+		})).id;
+		db.db.exec(`CREATE TRIGGER reject_topic_update BEFORE UPDATE OF topics ON thoughts
+			BEGIN SELECT RAISE(ABORT, 'unexpected metadata update'); END`);
+
+		const duplicate = parseResult(handleCaptureThought(db, {
+			content: "alpha bravo charlie delta echo",
+			project_identifier: "stable-noop",
+			topics: ["stable-topic"],
+			people: ["Alice"],
+		}));
+
+		expect(duplicate).toMatchObject({ id: first, action: "noop" });
+		expect(getThought(db.db, first)?.reinforcement_count).toBe(1);
 	});
 
   it("stamps project_identifier from cwd when not provided explicitly", () => {

--- a/tests/tools/context.test.ts
+++ b/tests/tools/context.test.ts
@@ -85,6 +85,15 @@ describe("handleSelectContext", () => {
     expect(data.document).toContain("Auth");
   });
 
+	it("canonicalizes its first topic filter", () => {
+		capture("Graph context", { topics: ["Knowledge Graph"], summary: "Graph" });
+
+		const data = parseResult(handleSelectContext(db, { topics: ["knowledge_graph"] }));
+
+		expect(data.matched_count).toBe(1);
+		expect(data.document).toContain("Graph context");
+	});
+
   it("filters by person", () => {
     capture("Tim said...", { people: ["Tim"], summary: "Tim quote" });
     capture("Sarah said...", { people: ["Sarah"], summary: "Sarah quote" });

--- a/tests/tools/get.test.ts
+++ b/tests/tools/get.test.ts
@@ -65,6 +65,7 @@ describe("handleGetThought", () => {
 		const thought = getThought(db.db, id)!;
 		expect(thought.reinforcement_count).toBe(1);
 		expect(thought.last_confirmed_at).toBeNull();
+		expect(parseResult(handleGetThought(db, { id })).reinforcement_count).toBe(2);
 	});
 
 	it("still returns the thought when reinforcement fails", () => {

--- a/tests/tools/get.test.ts
+++ b/tests/tools/get.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { ThoughtDatabase } from "../../src/db/database.js";
 import { handleGetThought } from "../../src/tools/get.js";
 import { handleCaptureThought } from "../../src/tools/capture.js";
+import { getThought } from "../../src/db/thoughts.js";
 
 let db: ThoughtDatabase;
 
@@ -55,4 +56,25 @@ describe("handleGetThought", () => {
     const data = JSON.parse(r.content[0].text);
     expect(data.error).toBe("not_found");
   });
+
+	it("reinforces a retrieved thought without confirming it", () => {
+		const id = parseResult(handleCaptureThought(db, { content: "Frequently useful" })).id;
+
+		handleGetThought(db, { id });
+
+		const thought = getThought(db.db, id)!;
+		expect(thought.reinforcement_count).toBe(1);
+		expect(thought.last_confirmed_at).toBeNull();
+	});
+
+	it("still returns the thought when reinforcement fails", () => {
+		const id = parseResult(handleCaptureThought(db, { content: "Readable regardless" })).id;
+		db.db.exec(`CREATE TRIGGER reject_reinforcement BEFORE UPDATE OF reinforcement_count ON thoughts
+			BEGIN SELECT RAISE(ABORT, 'blocked'); END`);
+
+		const data = parseResult(handleGetThought(db, { id }));
+
+		expect(data.id).toBe(id);
+		expect(data.content).toBe("Readable regardless");
+	});
 });

--- a/tests/tools/list.test.ts
+++ b/tests/tools/list.test.ts
@@ -71,6 +71,16 @@ describe("handleListThoughts", () => {
     expect(data.results.length).toBe(1);
   });
 
+	it("canonicalizes topic filters", () => {
+		captureId("Graph memory", { topics: ["Knowledge Graph"] });
+		captureId("Other memory", { topics: ["database"] });
+
+		const data = parseResult(handleListThoughts(db, { topic: "knowledge_graph" }));
+
+		expect(data.total_count).toBe(1);
+		expect(data.results[0].topics).toEqual(["knowledge-graph"]);
+	});
+
   it("filters by has_summary = false (missing summaries)", () => {
     captureId("Has summary", { summary: "A summary" });
     captureId("No summary");

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -53,6 +53,29 @@ describe("handleSearchThoughts", () => {
     expect(data.results[0].id).toBeDefined();
   });
 
+	it("records hashed search telemetry and rediscovery without raw query text", () => {
+		captureId("Telemetry alpha result");
+		captureId("Telemetry alpha second result");
+
+		handleSearchThoughts(db, { query: "telemetry alpha", all_projects: true });
+		handleSearchThoughts(db, { query: "telemetry alpha", all_projects: true });
+
+		const rows = db.db.prepare(
+			"SELECT query_hash, mode, result_count, top_ids, rediscovery, project_identifier FROM search_telemetry ORDER BY created_at, rowid",
+		).all() as Array<Record<string, unknown>>;
+		expect(rows).toHaveLength(2);
+		expect(rows[0]).toMatchObject({
+			mode: "fts",
+			result_count: 2,
+			rediscovery: 0,
+			project_identifier: null,
+		});
+		expect(rows[0].query_hash).toMatch(/^[a-f0-9]{64}$/);
+		expect(rows[0].query_hash).not.toBe("telemetry alpha");
+		expect(JSON.parse(rows[0].top_ids as string)).toHaveLength(2);
+		expect(rows[1].rediscovery).toBe(1);
+	});
+
   it("returns empty results for no FTS matches", () => {
     captureId("Hello world");
 
@@ -61,6 +84,18 @@ describe("handleSearchThoughts", () => {
     expect(data.results).toEqual([]);
     expect(data.total_count).toBe(0);
   });
+
+	it("canonicalizes topic filters for FTS search", () => {
+		const matching = captureId("Graph alpha memory", { topics: ["Knowledge Graph"] });
+		captureId("Graph beta memory", { topics: ["database"] });
+
+		const data = parseResult(handleSearchThoughts(db, {
+			query: "graph memory",
+			topic: "knowledge_graph",
+		}));
+
+		expect(data.results.map((result: { id: string }) => result.id)).toEqual([matching]);
+	});
 
   it("performs vector search when embedding is provided", () => {
     const id = captureId("Vector test thought");
@@ -255,9 +290,9 @@ describe("handleSearchThoughts", () => {
   });
 
   it("hybrid RRF type+project filter applies both constraints simultaneously", () => {
-    const idMatch = captureId("Database schema migration plan", { type: "decision", project: "proj-x" });
-    const idWrongType = captureId("Database schema migration plan", { type: "note", project: "proj-x" });
-    const idWrongProject = captureId("Database schema migration plan", { type: "decision", project: "proj-y" });
+    const idMatch = captureId("Database schema migration plan approved", { type: "decision", project: "proj-x" });
+    const idWrongType = captureId("Database schema migration plan approved", { type: "note", project: "proj-x" });
+    const idWrongProject = captureId("Database schema migration plan rejected", { type: "decision", project: "proj-y" });
 
     storeEmbedding(db.db, idMatch, [1.0, 0.0, 0.0]);
     storeEmbedding(db.db, idWrongType, [1.0, 0.0, 0.0]);

--- a/tests/tools/search.test.ts
+++ b/tests/tools/search.test.ts
@@ -76,6 +76,18 @@ describe("handleSearchThoughts", () => {
 		expect(rows[1].rediscovery).toBe(1);
 	});
 
+	it("keeps the previous telemetry top IDs in memory per database", () => {
+		captureId("Cached telemetry result");
+		handleSearchThoughts(db, { query: "cached telemetry", all_projects: true });
+		db.db.prepare("DELETE FROM search_telemetry").run();
+
+		handleSearchThoughts(db, { query: "cached telemetry", all_projects: true });
+
+		expect(db.db.prepare("SELECT rediscovery FROM search_telemetry").get()).toEqual({
+			rediscovery: 1,
+		});
+	});
+
   it("returns empty results for no FTS matches", () => {
     captureId("Hello world");
 

--- a/tests/tools/update.test.ts
+++ b/tests/tools/update.test.ts
@@ -134,4 +134,13 @@ describe("handleUpdateThought", () => {
 
     expect(getThought(db.db, id)!.visibility).toBe("shared");
   });
+
+	it("maps preference updates to the decision type", () => {
+		const id = captureId("Preference-shaped memory");
+
+		const result = handleUpdateThought(db, { id, type: "preference" });
+
+		expect(result.isError).toBeFalsy();
+		expect(getThought(db.db, id)?.type).toBe("decision");
+	});
 });


### PR DESCRIPTION
Implements #20, #21, #25, #23, #24, #18 (epic #17) — sprint batch A, 2026-08-14.

Note: migrations renumbered v9/v10 (issue bodies said v8/v9; v8 was taken by canonical project identity).

Independent check: full suite re-run by orchestrator outside the worker sandbox — **563/563 tests pass** (including the 4 localhost HTTP tests the worker's sandbox blocked), `npm run check` clean.

Closes #20, closes #21, closes #25, closes #23, closes #24, closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)